### PR TITLE
Fix uninitialized reads

### DIFF
--- a/multicast.c
+++ b/multicast.c
@@ -58,12 +58,11 @@ int setup_mcast(char const * const target,struct sockaddr *sock,int const output
     memset(sock,0,sizeof(struct sockaddr_storage));
   }
   char iface[1024];
+  iface[0] = '\0';
   if(target)
     resolve_mcast(target,sock,DEFAULT_RTP_PORT+offset,iface,sizeof(iface));
   if(strlen(iface) == 0 && Default_mcast_iface != NULL)
     strlcpy(iface,Default_mcast_iface,sizeof(iface));
-  else
-    iface[0] = '\0';
 
   if(output == 0)
     return listen_mcast(sock,iface);

--- a/radio.c
+++ b/radio.c
@@ -54,7 +54,7 @@ static float const SCALE8 = 1./INT8_MAX;  // Scale signed 8-bit int to float in 
 struct demod *alloc_demod(void){
   pthread_mutex_lock(&Demod_mutex);
   if(Demod_list == NULL){
-    Demod_list = (struct demod *)malloc(Demod_alloc_quantum*sizeof(struct demod));
+    Demod_list = (struct demod *)calloc(Demod_alloc_quantum,sizeof(struct demod));
     Demod_list_length = Demod_alloc_quantum;
     Active_demod_count = 0;
   }


### PR DESCRIPTION
Valgrind reports a couple places where data is used before it is initialized:

```
==12481== Conditional jump or move depends on uninitialised value(s)
==12481==    at 0x11E2D5: setup_mcast (multicast.c:63)
==12481==    by 0x10C70D: loadconfig (main.c:349)
==12481==    by 0x10BB6A: main (main.c:155)
```
If `target` is null, then the uninitialized `iface` will be passed into `strlen`.
```
==12481== Conditional jump or move depends on uninitialised value(s)
==12481==    at 0x113092: alloc_demod (radio.c:63)
==12481==    by 0x10C7FF: loadconfig (main.c:372)
==12481==    by 0x10BB6A: main (main.c:155)
```
The `inuse` field is read even though `Demod_list` is not initialized.

I've fixed both problems here.