### PR TITLE
Ignore Makefile symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.a
 *.o
+Makefile
 .depend
 airspy
 airspyhf


### PR DESCRIPTION
The installation instructions suggest creating a `Makefile` symlink, so it makes sense to include that in the list of files that git should ignore.