### PR TITLE
Check the return value of asprintf

### DIFF
--- a/airspy.c
+++ b/airspy.c
@@ -461,7 +461,10 @@ int main(int argc,char *argv[]){
   if(init_frequency != 0)
     sdr->frequency_lock = 1;
 
-  asprintf(&sdr->frequency_file,"%s/tune-airspy.%llx",VARDIR,(unsigned long long)sdr->SN);
+  ret = asprintf(&sdr->frequency_file,"%s/tune-airspy.%llx",VARDIR,(unsigned long long)sdr->SN);
+  if(ret == -1)
+    exit(1);
+
   if(init_frequency == 0){
     // If not set on command line, load saved frequency
     FILE *fp = fopen(sdr->frequency_file,"r+");

--- a/airspyhf.c
+++ b/airspyhf.c
@@ -413,7 +413,10 @@ int main(int argc,char *argv[]){
   if(init_frequency != 0)
     sdr->frequency_lock = 1;
 
-  asprintf(&sdr->frequency_file,"%s/tune-airspy.%llx",VARDIR,(unsigned long long)sdr->SN);
+  ret = asprintf(&sdr->frequency_file,"%s/tune-airspy.%llx",VARDIR,(unsigned long long)sdr->SN);
+  if(ret == -1)
+    exit(1);
+
   if(init_frequency == 0){
     // If not set on command line, load saved frequency
     FILE *fp = fopen(sdr->frequency_file,"r+");

--- a/funcube.c
+++ b/funcube.c
@@ -227,7 +227,9 @@ int main(int argc,char *argv[]){
     char *cp = strchr(hostname,'.');
     if(cp != NULL)
       *cp = '\0'; // Strip the domain name
-    asprintf(&Name,"%s-%d",hostname,Device);
+    int const ret = asprintf(&Name,"%s-%d",hostname,Device);
+    if(ret == -1)
+      exit(1);
   }
   {
     snprintf(Metadata_dest,sizeof(Metadata_dest),"funcube-%s-status.local",Name);

--- a/rtlsdr.c
+++ b/rtlsdr.c
@@ -291,7 +291,9 @@ int main(int argc,char *argv[]){
   // argv[optind] is presently just the USB device number, which is rather meaningless
   sdr->description = argv[optind];
   fprintf(stderr,"Rtlsdr handler %s: serial %llx\n",sdr->description,(long long unsigned)sdr->SN);
-  asprintf(&sdr->frequency_file,"%s/tune-rtlsdr.%llx",VARDIR,(unsigned long long)sdr->SN);
+  ret = asprintf(&sdr->frequency_file,"%s/tune-rtlsdr.%llx",VARDIR,(unsigned long long)sdr->SN);
+  if (ret == -1)
+    exit(1);
 
   // Set up output sockets
   if(sdr->data_dest == NULL){


### PR DESCRIPTION
gcc warns about a few places where the return value of `asprintf` is not checked. I've added checks here, and no warnings remain.