### PR TITLE
Fix signed integer overflows

### DIFF
--- a/airspyd.c
+++ b/airspyd.c
@@ -781,8 +781,8 @@ int rx_callback(airspy_transfer *transfer){
 // Not easy to fix without knowing the calibration parameters.
 // Best workaround is a GPSDO, which disables the correction
 double true_freq(uint64_t freq_hz){
-  int const VCO_MIN=1770000000u; // 1.77 GHz
-  int const VCO_MAX=(VCO_MIN << 1); // 3.54 GHz
+  uint32_t const VCO_MIN=1770000000u; // 1.77 GHz
+  uint32_t const VCO_MAX=(VCO_MIN << 1); // 3.54 GHz
   int const MAX_DIV = 5;
 
   // Clock divider set to 2 for the best resolution

--- a/avahi.c
+++ b/avahi.c
@@ -286,7 +286,7 @@ static int create_services(AvahiClient *c,struct userdata *userdata) {
 	if(iter == 100)
 	  return -1;
 
-	address.data.ipv4.address = htonl((0xef << 24) + (userdata->base_address & 0xffffff));
+	address.data.ipv4.address = htonl(((unsigned int)0xef << 24) + (userdata->base_address & 0xffffff));
 	userdata->base_address++;
 	char temp[1024];
 	int ret = avahi_entry_group_add_address(userdata->group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, userdata->dns_name,&address);

--- a/multicast.c
+++ b/multicast.c
@@ -281,7 +281,7 @@ void const *ntoh_rtp(struct rtp_header * const rtp,void const * const data){
 void *hton_rtp(void * const data, struct rtp_header const * const rtp){
   uint32_t *dp = data;
   int cc = rtp->cc & 0xf; // Ensure in range, <= 15
-  *dp++ = htonl(RTP_VERS << 30 | rtp->pad << 29 | rtp->extension << 28 | cc << 24 | rtp->marker << 23
+  *dp++ = htonl((unsigned int)RTP_VERS << 30 | rtp->pad << 29 | rtp->extension << 28 | cc << 24 | rtp->marker << 23
 		| (rtp->type & 0x7f) << 16 | rtp->seq);
   *dp++ = htonl(rtp->timestamp);
   *dp++ = htonl(rtp->ssrc);

--- a/rtlsdr.c
+++ b/rtlsdr.c
@@ -709,8 +709,8 @@ double true_freq(uint64_t freq){
 // For a requested frequency, give the actual tuning frequency
 // similar to the code in airspy.c since both use the R820T tuner
 double true_freq(uint64_t freq_hz){
-  const int VCO_MIN=1770000000u; // 1.77 GHz
-  const int VCO_MAX=(VCO_MIN << 1); // 3.54 GHz
+  const uint32_t VCO_MIN=1770000000u; // 1.77 GHz
+  const uint32_t VCO_MAX=(VCO_MIN << 1); // 3.54 GHz
   const int MAX_DIV = 5;
 
   // Clock divider set to 2 for the best resolution


### PR DESCRIPTION
GCC's Undefined Behaviour Sanitizer (`-fsanitize=undefined`) identifies several signed integer overflows when airspyd is started:
```
avahi.c:289:42: runtime error: left shift of 239 by 24 places cannot be represented in type 'int'
airspyd.c:785:30: runtime error: left shift of 1770000000 by 1 places cannot be represented in type 'int'
multicast.c:284:26: runtime error: left shift of 2 by 30 places cannot be represented in type 'int'
```
I've corrected those here by switching to unsigned integer types. I also corrected the same issue in rtlsdr.