### PR TITLE
Terminate longopts arrays

### DIFF
--- a/setfilt.c
+++ b/setfilt.c
@@ -35,6 +35,7 @@ struct option Options[] = {
     {"radio", required_argument, NULL, 'r'},
     {"locale", required_argument, NULL, 'l'},
     {"verbose", no_argument, NULL, 'v'},
+    {NULL, 0, NULL, 0},
 };
 
 int main(int argc,char *argv[]){

--- a/tune.c
+++ b/tune.c
@@ -34,6 +34,7 @@ struct option Options[] = {
     {"radio", required_argument, NULL, 'r'},
     {"locale", required_argument, NULL, 'l'},
     {"verbose", no_argument, NULL, 'v'},
+    {NULL, 0, NULL, 0},
 };
 
 int main(int argc,char *argv[]){


### PR DESCRIPTION
The "tune" and "setfilt" programs currently crash if an invalid command line argument is given (e.g. `tune --foo` or `setfilt --foo`). This happens because the `longopts` arrays passed into `getopt_long` are not terminated. I've added the missing terminations here.