### PR TITLE
tune.c no break at end of case

### DIFF
--- a/tune.c
+++ b/tune.c
@@ -51,6 +51,7 @@ int main(int argc,char *argv[]){
       switch(c){
       case 's':
 	Ssrc = strtol(optarg,NULL,0);
+	break;
       case 'v':
 	Verbose++;
 	break;


### PR DESCRIPTION
This was called out as a possible error by Eclipse IDE. Basically it enables 'verbose' option when using the 'Ssrc' option.
