### PR TITLE
Add glib dependency to macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           brew update
           brew install \
+            glib \
             libusb \
             ncurses \
             fftw \


### PR DESCRIPTION
This package is required to build avahi.

Fixes #21.