### PR TITLE
fix build on Arch Linux

### DIFF
--- a/Makefile.debug
+++ b/Makefile.debug
@@ -11,6 +11,7 @@ COPTS=-march=native -std=gnu11 -pthread -Wall -funsafe-math-optimizations -D_GNU
 #LDOPTS=-L/usr/local/lib
 #LDOPTS=-g -L/usr/local/lib
 
+INCLUDES+=-I/usr/include/iniparser/
 CFLAGS=$(DOPTS) $(COPTS) $(INCLUDES)
 BINDIR=/usr/local/bin
 LIBDIR=/usr/local/share/ka9q-radio

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -11,6 +11,7 @@ COPTS=-march=native -std=gnu11 -pthread -Wall -funsafe-math-optimizations -D_GNU
 LDOPTS=-L/usr/local/lib
 #LDOPTS=-g -L/usr/local/lib
 
+INCLUDES+=-I/usr/include/iniparser/
 CFLAGS=$(DOPTS) $(COPTS) $(INCLUDES)
 BINDIR=/usr/local/bin
 LIBDIR=/usr/local/share/ka9q-radio

--- a/airspyd.c
+++ b/airspyd.c
@@ -27,7 +27,7 @@
 #include <syslog.h>
 #include <sys/stat.h>
 #include <getopt.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 
 #include "conf.h"
 #include "misc.h"

--- a/airspyhfd.c
+++ b/airspyhfd.c
@@ -26,7 +26,7 @@
 #include <syslog.h>
 #include <sys/stat.h>
 #include <getopt.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 
 #include "conf.h"
 #include "misc.h"

--- a/config.c
+++ b/config.c
@@ -1,7 +1,7 @@
 // $Id: config.c,v 1.4 2022/04/20 05:37:31 karn Exp $
 // Helper functions for iniparser that combine section:key
 // April 2022, Phil Karn, KA9Q
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 #include "config.h"
 
 int config_getint(dictionary const *d,char const *section,char const *key,int def){

--- a/control.c
+++ b/control.c
@@ -29,7 +29,7 @@
 #include <locale.h>
 #include <signal.h>
 #include <sys/ioctl.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 
 #include "misc.h"
 #include "filter.h"

--- a/funcubed.c
+++ b/funcubed.c
@@ -31,7 +31,7 @@
 #include <syslog.h>
 #include <errno.h>
 #include <getopt.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 
 #include "conf.h"
 #include "fcd.h"

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@
 #include <getopt.h>
 #include <ctype.h>
 #include <arpa/inet.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 #include <net/if.h>
 
 #include "misc.h"

--- a/modes.c
+++ b/modes.c
@@ -15,7 +15,7 @@
 #endif
 #include <string.h>
 #include <ctype.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 #include <pthread.h>
 
 #include "misc.h"

--- a/radio.h
+++ b/radio.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <limits.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 
 #include "multicast.h"
 #include "osc.h"

--- a/sdrplayd.c
+++ b/sdrplayd.c
@@ -27,7 +27,7 @@
 #include <syslog.h>
 #include <sys/stat.h>
 #include <getopt.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 
 #include "conf.h"
 #include "misc.h"


### PR DESCRIPTION
The header iniparser.h on Arch linux is not in subdirectory, this is a bit hacky approach bud should allow build on both Ubuntu and Arch Linux.

The other options to consider is to add more aleborate build system (like CMake), I can try to do that if desired.