### PR TITLE
rtlsdr: increase the block size to 1298

### DIFF
--- a/rtlsdr.c
+++ b/rtlsdr.c
@@ -40,7 +40,7 @@
 
 // Internal clock is 28.8 MHz, and 1.8 MHz * 16 = 28.8 MHz
 #define DEFAULT_SAMPRATE (1800000)
-#define DEFAULT_BLOCKSIZE (960)
+#define DEFAULT_BLOCKSIZE (1280)
 
 #define N_serials 20
 uint64_t Serials[N_serials];


### PR DESCRIPTION
I'm completely ignorant why 960 was used and there is no documentation, any special reason?

This reduces the number of packets to send (and thus switching overhead), it is also 2*512+256 -> it is better aligned with USB transfer size.

Btw, when jumbo frames are used, then the 8192 block size works like a charm, would make sense to make this configurable?