### PR TITLE
Fix rtlsdr -> rtlsdrd rename

### DIFF
--- a/Makefile.debug
+++ b/Makefile.debug
@@ -106,7 +106,7 @@ control: control.o modes.o bandplan.o decode_status.o libradio.a
 cwd: cwd.o morse.o libradio.a
 	$(CC) $(LDOPTS) -o $@ $^ -lbsd -lpthread -lm
 
-rtlsdr: rtlsdrd.o libradio.a
+rtlsdrd: rtlsdrd.o libradio.a
 	$(CC) $(LDOPTS) -o $@ $^ -lrtlsdr -lavahi-client -lavahi-common -lbsd -lm -lpthread
 
 tune: tune.o libradio.a

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ use by other programs.
 Separate programs talk directly to several makes of SDR front end
 hardware and generates the I/Q stream for *radiod*. These programs
 currently include *airspyd* (Airspy R2), *airspyhfd* (Airspy HF+),
-*rtlsdr* (generic RTL-SDR dongles), *funcubed* (AMSAT UK Funcube Pro+)
+*rtlsdrd* (generic RTL-SDR dongles), *funcubed* (AMSAT UK Funcube Pro+)
 and *hackrf* (Great Scott Gadgets Hack RF One, receive only).
 
 Two very rudimentary programs are provided for interactive use;

--- a/rtlsdrd.c
+++ b/rtlsdrd.c
@@ -1,4 +1,4 @@
-// $Id: rtlsdr.c,v 1.22 2022/08/05 06:35:10 karn Exp $
+// $Id: rtlsdrd.c,v 1.22 2022/08/05 06:35:10 karn Exp $
 // Read from RTL SDR
 // Accept control commands from UDP socket
 #define _GNU_SOURCE 1


### PR DESCRIPTION
Add missing renames for the  rtlsdr -> rtlsdrd rename.