### PR TITLE
Add DEFAULT_SOURCE Define

### DIFF
--- a/multicast.c
+++ b/multicast.c
@@ -1,7 +1,7 @@
 // $Id: multicast.c,v 1.91 2022/10/25 01:57:52 karn Exp $
 // Multicast socket and RTP utility routines
 // Copyright 2018 Phil Karn, KA9Q
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE 1
 
 #include <stdio.h>
 #include <unistd.h>

--- a/multicast.c
+++ b/multicast.c
@@ -1,6 +1,7 @@
 // $Id: multicast.c,v 1.91 2022/10/25 01:57:52 karn Exp $
 // Multicast socket and RTP utility routines
 // Copyright 2018 Phil Karn, KA9Q
+#define _DEFAULT_SOURCE
 
 #include <stdio.h>
 #include <unistd.h>

--- a/set_xcvr.c
+++ b/set_xcvr.c
@@ -1,4 +1,6 @@
 // $Id: set_xcvr.c,v 1.4 2022/12/29 05:40:08 karn Exp $
+#define _GNU_SOURCE 1
+
 #include <termios.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Without this define on Linux, the macros like NI_MAXHOST didn't get defined in multicast.c

Linux 5.15.0-67-generic #74-Ubuntu SMP Wed Feb 22 14:14:39 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0

Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.2 LTS
Release:	22.04
Codename:	jammy

VS Code Version 1.76.0
