### PR TITLE
Remove references to wspr-decoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ show-sig
 stereod
 tune
 wd-record
-wspr-decoded
 old
 RCS
 push.sh

--- a/Makefile.debug
+++ b/Makefile.debug
@@ -18,7 +18,7 @@ LDLIBS=-lpthread -lbsd -lm
 
 DAEMONS=aprs aprsfeed cwd opusd packetd radiod stereod rdsd
 
-EXECS=control jt-decoded metadump monitor opussend pcmcat pcmrecord pcmsend pcmspawn pl powers setfilt show-pkt show-sig tune wd-record wspr-decoded
+EXECS=control jt-decoded metadump monitor opussend pcmcat pcmrecord pcmsend pcmspawn pl powers setfilt show-pkt show-sig tune wd-record
 
 
 LOGROTATE_FILES = aprsfeed.rotate

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -18,7 +18,7 @@ LDLIBS=-lpthread -lbsd -lm
 
 DAEMONS=aprs aprsfeed cwd opusd packetd radiod stereod rdsd
 
-EXECS=control jt-decoded metadump monitor opussend pcmcat pcmrecord pcmsend pcmspawn pl powers setfilt show-pkt show-sig tune wd-record wspr-decoded
+EXECS=control jt-decoded metadump monitor opussend pcmcat pcmrecord pcmsend pcmspawn pl powers setfilt show-pkt show-sig tune wd-record
 
 
 LOGROTATE_FILES = aprsfeed.rotate


### PR DESCRIPTION
wspr-decoded was removed in e8190a55304f093727cd3ca48488c7f68f58c6e4, but it is still referenced in the Linux makefiles, causing the build to fail (unless a stale wspr-decoded executable happens to be around from a previous compile). Here I've removed the references, after which CI should pass again.

I also removed wspr-decodec from .gitignore, where it should no longer be required.