### PR TITLE
Modify pcmrecord length limit to consider number of channels

### DIFF
--- a/pcmrecord.c
+++ b/pcmrecord.c
@@ -60,7 +60,7 @@ struct session {
 
   uint32_t ssrc;               // RTP stream source ID
   struct rtp_state rtp_state;
-  
+
   int type;                    // RTP payload type (with marker stripped)
   int channels;                // 1 (PCM_MONO) or 2 (PCM_STEREO)
   unsigned int samprate;       // implicitly 48 kHz in PCM
@@ -106,7 +106,7 @@ static struct option Options[] = {
   {"mintime", required_argument, NULL, 'm'},
   {"samprate", required_argument, NULL, 'r'},
   {"subdirectories", no_argument, NULL, 's'},
-  {"subdirs", no_argument, NULL, 's'},    
+  {"subdirs", no_argument, NULL, 's'},
   {"timeout", required_argument, NULL, 't'},
   {"verbose", no_argument, NULL, 'v'},
   {"lengthlimit", required_argument, NULL, 'L'},
@@ -147,7 +147,7 @@ int main(int argc,char *argv[]){
     case 't':
       {
 	char *ptr;
-	int64_t x = strtoll(optarg,&ptr,0); 
+	int64_t x = strtoll(optarg,&ptr,0);
 	if(ptr != optarg)
 	  Timeout = x;
       }
@@ -201,7 +201,7 @@ int main(int argc,char *argv[]){
   signal(SIGINT,closedown);
   signal(SIGKILL,closedown);
   signal(SIGQUIT,closedown);
-  signal(SIGTERM,closedown);        
+  signal(SIGTERM,closedown);
   signal(SIGPIPE,SIG_IGN);
 
   atexit(cleanup);
@@ -244,7 +244,7 @@ static void input_loop(){
       }
       if(size < RTP_MIN_SIZE)
 	continue; // Too small for RTP, ignore
-      
+
       struct rtp_header rtp;
       uint8_t const * const dp = ntoh_rtp(&rtp,buffer);
       if(rtp.pad){
@@ -254,10 +254,10 @@ static void input_loop(){
       }
       if(size <= 0)
 	continue; // Bogus RTP header
-      
+
       int16_t const * const samples = (int16_t *)dp;
       size -= (dp - buffer);
-      
+
       struct session *sp;
       for(sp = Sessions;sp != NULL;sp=sp->next){
 	if(sp->ssrc == rtp.ssrc
@@ -288,7 +288,7 @@ static void input_loop(){
       int const samp_count = size / sizeof(*samples); // number of individual audio samples (not frames)
       int const frame_count = samp_count / sp->channels; // 1 every sample period (e.g., 4 for stereo 16-bit)
       off_t const offset = rtp_process(&sp->rtp_state,&rtp,frame_count); // rtp timestamps refer to frames
-      
+
       // The seek offset relative to the current position in the file is the signed (modular) difference between
       // the actual and expected RTP timestamps. This should automatically handle
       // 32-bit RTP timestamp wraps, which occur every ~1 days at 48 kHz and only 6 hr @ 192 kHz
@@ -332,7 +332,7 @@ static void input_loop(){
     }
   }
 }
- 
+
 static void cleanup(void){
   while(Sessions){
     // Flush and close each write stream
@@ -347,26 +347,26 @@ static struct session *create_session(struct rtp_header const *rtp,struct sockad
   struct session *sp = calloc(1,sizeof(*sp));
   if(sp == NULL)
     return NULL; // unlikely
-  
+
   memcpy(&sp->sender,sender,sizeof(sp->sender));
   sp->type = rtp->type;
   sp->ssrc = rtp->ssrc;
-  
+
   sp->channels = Channels ? Channels : channels_from_pt(sp->type);
   sp->samprate = Samprate ? Samprate : samprate_from_pt(sp->type);
   if(sp->channels == 0 || sp->samprate == 0){
     fprintf(stderr,"Unknown payload type %d and channels/samprate not specified on command line\n",sp->type);
     return NULL;
   }
-  sp->samples_remaining = sp->samprate * FileLengthLimit; // If file is being limited in length
-  
+  sp->samples_remaining = sp->samprate * FileLengthLimit * Channels; // If file is being limited in length
+
   // Create file
   // Should we append to existing files instead? If we try this, watch out for timestamp wraparound
   struct timespec now;
   clock_gettime(CLOCK_REALTIME,&now);
   struct tm const * const tm = gmtime(&now.tv_sec);
   // yyyy-mm-dd-hh:mm:ss so it will sort properly
-  
+
   sp->fp = NULL;
   if(Subdirs){
     char dir[PATH_MAX];
@@ -402,7 +402,7 @@ static struct session *create_session(struct rtp_header const *rtp,struct sockad
 	     tm->tm_sec,
 	     (int)(now.tv_nsec / 100000000));
     sp->fp = fopen(sp->filename,"w+");
-  }    
+  }
   if(sp->fp == NULL){
     fprintf(stderr,"can't create/write file %s: %s\n",sp->filename,strerror(errno));
     FREE(sp);
@@ -411,26 +411,26 @@ static struct session *create_session(struct rtp_header const *rtp,struct sockad
   // file create succeded, now put us at top of list
   sp->prev = NULL;
   sp->next = Sessions;
-  
+
   if(sp->next)
     sp->next->prev = sp;
-  
+
   Sessions = sp;
 
   if(Verbose)
     fprintf(stdout,"creating %s\n",sp->filename);
-  
+
   sp->iobuffer = malloc(BUFFERSIZE);
   setbuffer(sp->fp,sp->iobuffer,BUFFERSIZE);
-  
+
   int const fd = fileno(sp->fp);
   fcntl(fd,F_SETFL,O_NONBLOCK); // Let's see if this keeps us from losing data
-  
+
   attrprintf(fd,"samplerate","%lu",(unsigned long)sp->samprate);
   attrprintf(fd,"channels","%d",sp->channels);
   attrprintf(fd,"ssrc","%u",rtp->ssrc);
   attrprintf(fd,"sampleformat","s16le");
-  
+
   // Write .wav header, skipping size fields
   memcpy(sp->header.ChunkID,"RIFF", 4);
   sp->header.ChunkSize = 0xffffffff; // Temporary
@@ -440,7 +440,7 @@ static struct session *create_session(struct rtp_header const *rtp,struct sockad
   sp->header.AudioFormat = 1;
   sp->header.NumChannels = sp->channels;
   sp->header.SampleRate = sp->samprate;
-  
+
   sp->header.ByteRate = sp->samprate * sp->channels * 16/8;
   sp->header.BlockAlign = sp->channels * 16/8;
   sp->header.BitsPerSample = 16;
@@ -454,7 +454,7 @@ static struct session *create_session(struct rtp_header const *rtp,struct sockad
   getnameinfo((struct sockaddr *)sender,sizeof(*sender),sender_text,sizeof(sender_text),NULL,0,NI_NOFQDN|NI_DGRAM|NI_NUMERICHOST);
   attrprintf(fd,"source","%s",sender_text);
   attrprintf(fd,"multicast","%s",PCM_mcast_address_text);
-  
+
   attrprintf(fd,"unixstarttime","%ld.%09ld",(long)now.tv_sec,(long)now.tv_nsec);
   return sp;
 }
@@ -467,8 +467,8 @@ static int close_file(struct session **spp){
   if(sp->substantial_file){ // Don't bother for non-substantial files
     if(Verbose){
       fprintf(stdout,"closing %s %'.1f/%'.1f sec\n",sp->filename,
-	     (float)sp->samples_written / sp->samprate,
-	     (float)sp->total_file_samples / sp->samprate);
+            (float)sp->samples_written / (sp->samprate * Channels),
+            (float)sp->total_file_samples / (sp->samprate *Channels));
     }
     // Get final file size, write .wav header with sizes
     fflush(sp->fp);
@@ -488,8 +488,8 @@ static int close_file(struct session **spp){
     unlink(sp->filename);
     if(Verbose)
       printf("deleting %s %'.1f/%'.1f sec\n",sp->filename,
-	     (float)sp->samples_written / sp->samprate,
-	     (float)sp->total_file_samples / sp->samprate);
+            (float)sp->samples_written / (sp->samprate * Channels),
+            (float)sp->total_file_samples / (sp->samprate * Channels));
   }
   fclose(sp->fp);
   sp->fp = NULL;


### PR DESCRIPTION
pcmrecord length limit and diag output assumes single channel files.