### PR TITLE
Fix the memory deallocation bug in pcmrecord

### DIFF
--- a/pcmrecord.c
+++ b/pcmrecord.c
@@ -500,6 +500,7 @@ static int close_file(struct session **spp){
     Sessions = sp->next;
   if(sp->next)
     sp->next->prev = sp->prev;
-  FREE(*spp);
+  FREE(sp);
+  sp=0;
   return 0;
 }


### PR DESCRIPTION
Recording multiple .wav files with pcmrecord would fail when closing the sessions. Usually the first one or two files would close ok, but the rest would fail.

For example: pcmrecord -c1 -v -L6 wwv-pcm.local
creating 15000k2024-03-31T23:57:10.1Z.wav
creating 3300k2024-03-31T23:57:10.1Z.wav
creating 5000k2024-03-31T23:57:10.1Z.wav
creating 25000k2024-03-31T23:57:10.1Z.wav
creating 2500k2024-03-31T23:57:10.1Z.wav
creating 14670k2024-03-31T23:57:10.1Z.wav
creating 20000k2024-03-31T23:57:10.1Z.wav
creating 10000k2024-03-31T23:57:10.1Z.wav
creating 7850k2024-03-31T23:57:10.1Z.wav
closing 7850k2024-03-31T23:57:10.1Z.wav 6.0/6.0 sec
closing 10000k2024-03-31T23:57:10.1Z.wav 6.0/6.0 sec
double free or corruption (!prev)
Aborted
