### PR TITLE
Fix signed integer overflows

### DIFF
--- a/main.c
+++ b/main.c
@@ -313,7 +313,7 @@ static int loadconfig(char const * const file){
     snprintf(ttlmsg,sizeof(ttlmsg),"TTL=%d",Mcast_ttl);
 
     int slen = sizeof(Template.output.dest_socket);
-    uint32_t addr = (239 << 24) | (ElfHashString(Data) & 0xffffff); // Force into site-local multicast space
+    uint32_t addr = (239U << 24) | (ElfHashString(Data) & 0xffffff); // Force into site-local multicast space
     avahi_start(Name,"_rtp._udp",DEFAULT_RTP_PORT,Data,addr,ttlmsg,&Template.output.dest_socket,&slen);
 #if 0
     avahi_start(Name,"_ka9q-ctl._udp",DEFAULT_STAT_PORT,Data,addr,ttlmsg,&Template.status.dest_socket,&slen); // same length
@@ -392,7 +392,7 @@ static int loadconfig(char const * const file){
     snprintf(ttlmsg,sizeof(ttlmsg),"TTL=%d",Mcast_ttl);
     int slen = sizeof(Metadata_socket);
     uint32_t addr = ElfHashString(Metadata_string);
-    addr = (239 << 24) | (addr & 0xffffff); // Force into site-local multicast space
+    addr = (239U << 24) | (addr & 0xffffff); // Force into site-local multicast space
     avahi_start(Frontend.description != NULL ? Frontend.description : Name,"_ka9q-ctl._udp",DEFAULT_STAT_PORT,Metadata_string,addr,ttlmsg,&Metadata_socket,&slen);
   }
   // avahi_start has resolved the target DNS name into Metadata_socket and inserted the port number
@@ -457,7 +457,7 @@ static int loadconfig(char const * const file){
       snprintf(ttlmsg,sizeof(ttlmsg),"TTL=%d",Mcast_ttl);
 
       int slen = sizeof(data_dest_socket);
-      uint32_t addr = (239 << 24) | (ElfHashString(data) & 0xffffff); // Force into site-local multicast space
+      uint32_t addr = (239U << 24) | (ElfHashString(data) & 0xffffff); // Force into site-local multicast space
       avahi_start(sname,"_rtp._udp",DEFAULT_RTP_PORT,data,addr,ttlmsg,&data_dest_socket,&slen);
 #if 0
       avahi_start(sname,"_ka9q-ctl._udp",DEFAULT_STAT_PORT,data,addr,ttlmsg,&metadata_dest_socket,&slen); // sockets are same size

--- a/opusd.c
+++ b/opusd.c
@@ -242,7 +242,7 @@ int main(int argc,char * const argv[]){
   char description[1024];
   snprintf(description,sizeof(description),"pcm-source=%s",Input); // what if it changes?
   int socksize = sizeof(Opus_dest_socket);
-  uint32_t addr = (239 << 24) | (ElfHashString(Output) & 0xffffff);
+  uint32_t addr = (239U << 24) | (ElfHashString(Output) & 0xffffff);
   avahi_start(Name,"_opus._udp",5004,Output,addr,description,&Opus_dest_socket,&socksize);
 
   // Can't resolve this until the avahi service is started

--- a/packetd.c
+++ b/packetd.c
@@ -232,7 +232,7 @@ int main(int argc,char *argv[]){
 	break; // Too long!
       p += snprintf(&description[p],sizeof(description)-p,"%s%s",i > 0 ? "," : "" ,Input[i]);
     }
-    uint32_t addr = (239 << 24) | (ElfHashString(Output) & 0xffffff);
+    uint32_t addr = (239U << 24) | (ElfHashString(Output) & 0xffffff);
     avahi_start(Name,"_ax25._udp",DEFAULT_RTP_PORT,Output,addr,description,NULL,NULL);
   }
   Output_fd = setup_mcast(Output,NULL,1,Mcast_ttl,IP_tos,0);

--- a/rdsd.c
+++ b/rdsd.c
@@ -173,7 +173,7 @@ int main(int argc,char * const argv[]){
     snprintf(service_name,sizeof(service_name),"%s (%s)",Name,output);
     char description[1024];
     snprintf(description,sizeof(description),"pcm-source=%s",Input);
-    uint32_t addr = (239 << 24) | (ElfHashString(output) & 0xffffff);
+    uint32_t addr = (239U << 24) | (ElfHashString(output) & 0xffffff);
     avahi_start(service_name,"_rtp._udp",DEFAULT_RTP_PORT,output,addr,description,NULL,NULL);
 
     resolve_mcast(output,&Stereo_dest_address,DEFAULT_RTP_PORT,NULL,0);

--- a/sdrplayd.c
+++ b/sdrplayd.c
@@ -468,10 +468,10 @@ int main(int argc,char *argv[]){
     // Description, if present becomes TXT record if present
     char service_name[1024];
     snprintf(service_name,sizeof(service_name),"%s (%s)",sdr->description,sdr->metadata_dest);
-    uint32_t addr = (239 << 24) | (ElfHashString(sdr->metadata_dest) & 0xffffff);
+    uint32_t addr = (239U << 24) | (ElfHashString(sdr->metadata_dest) & 0xffffff);
     avahi_start(service_name,"_ka9q-ctl._udp",5006,sdr->metadata_dest,addr,sdr->description);
     snprintf(service_name,sizeof(service_name),"%s (%s)",sdr->description,sdr->data_dest);
-    addr = (239 << 24) | (ElfHashString(sdr->data_dest) & 0xffffff);
+    addr = (239U << 24) | (ElfHashString(sdr->data_dest) & 0xffffff);
     avahi_start(service_name,"_rtp._udp",5004,sdr->data_dest,addr,sdr->description);
   }
   {

--- a/stereod.c
+++ b/stereod.c
@@ -192,7 +192,7 @@ int main(int argc,char * const argv[]){
     snprintf(service_name,sizeof(service_name),"%s (%s)",Name,Output);
     char description[1024];
     snprintf(description,sizeof(description),"pcm-source=%s",formatsock(&PCM_dest_address));
-    uint32_t addr = (239 << 24) | (ElfHashString(Output) & 0xffffff);
+    uint32_t addr = (239U << 24) | (ElfHashString(Output) & 0xffffff);
     avahi_start(service_name,"_rtp._udp",DEFAULT_RTP_PORT,Output,addr,description,NULL,NULL);
     resolve_mcast(Output,&Stereo_dest_address,DEFAULT_RTP_PORT,NULL,0);
     Output_fd = connect_mcast(&Stereo_dest_address,NULL,Mcast_ttl,IP_tos);


### PR DESCRIPTION
UBSAN (`-fsanitize=undefined`) reports signed integer overflows, e.g.:
```
main.c:316:26: runtime error: left shift of 239 by 24 places cannot be represented in type 'int'
```
Switching 239 to unsigned solves the problem.