### PR TITLE
Fix macOS CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             libavahi-client-dev \
             portaudio19-dev
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         run: ln -s ${{ matrix.makefile }} Makefile
       - name: Compile
@@ -76,7 +76,7 @@ jobs:
           make -j4
           sudo make install
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         run: ln -s Makefile.osx Makefile
       - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,15 @@ jobs:
             iniparser \
             portaudio \
             dbus
-          ln -s /usr/local/Cellar/iniparser/*/include /usr/local/include/iniparser
+          mkdir -p "$(brew --prefix)/include/iniparser"
+          ln -s "$(brew --prefix)/include/iniparser.h" "$(brew --prefix)/include/iniparser/iniparser.h"
 
           cd /tmp
           curl https://avahi.org/download/avahi-0.8.tar.gz > avahi-0.8.tar.gz
           tar xvpf avahi-0.8.tar.gz
           cd avahi-0.8
           sed -i '' 's/"\/run"/"\/var\/run"/' configure
-          CFLAGS="-D__APPLE_USE_RFC_2292" ./configure \
+          CFLAGS="-D__APPLE_USE_RFC_2292 -I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib" ./configure \
             --with-distro=darwin \
             --disable-autoipd \
             --disable-gtk3 \
@@ -79,6 +80,6 @@ jobs:
       - name: Setup
         run: ln -s Makefile.osx Makefile
       - name: Compile
-        run: make
+        run: C_INCLUDE_PATH="$(brew --prefix)/include" LIBRARY_PATH="$(brew --prefix)/lib" make
       - name: Install
         run: sudo make install

--- a/airspy.c
+++ b/airspy.c
@@ -13,6 +13,7 @@
 #endif
 #include <sysexits.h>
 #include <unistd.h>
+#include <strings.h>
 
 #include "conf.h"
 #include "misc.h"

--- a/airspyhf.c
+++ b/airspyhf.c
@@ -13,6 +13,7 @@
 #endif
 #include <sysexits.h>
 #include <unistd.h>
+#include <strings.h>
 
 #include "conf.h"
 #include "misc.h"

--- a/decode_status.c
+++ b/decode_status.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "radio.h"
 
 // Decode incoming status message from the radio program, convert and fill in fields in local channel structure

--- a/funcube.c
+++ b/funcube.c
@@ -10,6 +10,7 @@
 #include <bsd/string.h>
 #endif
 #include <sysexits.h>
+#include <strings.h>
 
 #include "conf.h"
 #include "fcd.h"

--- a/main.c
+++ b/main.c
@@ -30,6 +30,7 @@
 #include <sched.h>
 #include <sysexits.h>
 #include <fcntl.h>
+#include <strings.h>
 
 #include "misc.h"
 #include "multicast.h"

--- a/rtlsdr.c
+++ b/rtlsdr.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <iniparser/iniparser.h>
 #include <sysexits.h>
+#include <strings.h>
 
 #include "conf.h"
 #include "misc.h"

--- a/rx888.c
+++ b/rx888.c
@@ -16,6 +16,7 @@
 #endif
 #include <sysexits.h>
 #include <unistd.h>
+#include <strings.h>
 
 #include "misc.h"
 #include "status.h"

--- a/sig_gen.c
+++ b/sig_gen.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #endif
 #include <sysexits.h>
+#include <strings.h>
 
 #include "conf.h"
 #include "fcd.h"


### PR DESCRIPTION
The macOS CI build began failing when macOS 14 became the default on Github Actions. I made the following changes to fix that:

* Use `$(brew --prefix)` to determine where Homebrew has installed packages, instead of using hard-coded paths.
* Add missing `#include` directives.

Also, I updated the checkout actions to version 4, which fixes deprecation warnings.