### PR TITLE
Remove workaround for homebrew iniparser package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
             iniparser \
             portaudio \
             dbus
-          mkdir -p "$(brew --prefix)/include/iniparser"
-          ln -s "$(brew --prefix)/include/iniparser.h" "$(brew --prefix)/include/iniparser/iniparser.h"
 
           cd /tmp
           curl https://avahi.org/download/avahi-0.8.tar.gz > avahi-0.8.tar.gz


### PR DESCRIPTION
When setting up the macOS CI build, I had to add a workaround because Homebrew was installing `iniparser.h` to the wrong directory. They have now fixed that, which causes my workaround to fail. I have removed the workaround here, and verified that the CI build succeeds on my fork.