### PR TITLE
Don't discard calibrate setting

### DIFF
--- a/airspy.c
+++ b/airspy.c
@@ -183,7 +183,6 @@ int airspy_setup(struct frontend * const frontend,dictionary * const Dictionary,
     ret = airspy_set_samplerate(sdr->device,(uint32_t)frontend->samprate);
     assert(ret == AIRSPY_SUCCESS);
   }
-  frontend->calibrate = 0;
   frontend->max_IF = -600000;
   frontend->min_IF = -0.47 * frontend->samprate;
 


### PR DESCRIPTION
The airspy frontend discards the `calibrate` setting just after reading it. This appears to be an oversight, which I've corrected here.