### PR TITLE
Add libogg dependency to CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
             libfftw3-dev \
             libbsd-dev \
             libhackrf-dev \
+            libogg-dev \
             libopus-dev \
             libairspy-dev \
             libairspyhf-dev \
@@ -48,6 +49,7 @@ jobs:
             ncurses \
             fftw \
             hackrf \
+            libogg \
             opus \
             airspy \
             airspyhf \


### PR DESCRIPTION
ka9q-radio now depends on libogg, so it needs to be added to the CI workflows. I've done that here, and the CI runs now pass.