### PR TITLE
Round bin powers to two decimal places

### DIFF
--- a/powers.c
+++ b/powers.c
@@ -214,20 +214,20 @@ int main(int argc,char *argv[]){
     // Frequencies below center
     printf("\n");
     for(int i=first_neg_bin ; i < npower; i++){
-      printf("%d %f %.1f\n",i,base,(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
+      printf("%d %f %.2f\n",i,base,(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
       base += r_bin_bw;
     }
     // Frequencies above center
     for(int i=0; i < first_neg_bin; i++){
-      printf("%d %f %.1f\n",i,base,(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
+      printf("%d %f %.2f\n",i,base,(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
       base += r_bin_bw;
     }
 #else
     for(int i= first_neg_bin; i < npower; i++)
-      printf(", %.1f",(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
+      printf(", %.2f",(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
     // Frequencies above center
     for(int i=0; i < first_neg_bin; i++)
-      printf(", %.1f",(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
+      printf(", %.2f",(powers[i] == 0) ? -100.0 : 10*log10(powers[i]));
 #endif
     printf("\n");
     if(--count == 0)


### PR DESCRIPTION
The "powers" utility currently rounds bin powers to one decimal place. When using a long integration period (like Radiosonde Auto-RX does), quantization becomes readily visible:

![Screenshot from 2024-12-07 11-12-16](https://github.com/user-attachments/assets/888dd003-bb6d-4353-8556-514d5a66043f)

I think it would make sense to increase the precision to two decimal places. This would also match the behaviour of rtl_power.