### PR TITLE
Use ISO 8601 format for time in powers output

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -153,6 +153,10 @@ char *format_gpstime(char *result,int len,int64_t t){
   return format_utctime(result,len,t + BILLION * (UNIX_EPOCH - GPS_UTC_OFFSET));
 }
 
+char *format_gpstime_iso8601(char *result,int len,int64_t t){
+  return format_utctime_iso8601(result,len,t + BILLION * (UNIX_EPOCH - GPS_UTC_OFFSET));
+}
+
 
 // Format, as UTC, a time measured in nanoseconds from the UNIX epoch
 char *format_utctime(char *result,int len,int64_t t){
@@ -179,6 +183,31 @@ char *format_utctime(char *result,int len,int64_t t){
 
   return result;
 }
+
+char *format_utctime_iso8601(char *result,int len,int64_t t){
+  lldiv_t const ut = lldiv(t,BILLION);
+
+  time_t utime = ut.quot;
+  int t_usec = ut.rem / 1000;
+  if(t_usec < 0){
+    t_usec += 1000000;
+    utime -= 1;
+  }
+  struct tm tm;
+  gmtime_r(&utime,&tm);
+  // 2018-02-26T14:40:08.123456Z
+  snprintf(result,len,"%04d-%02d-%02dT%02d:%02d:%02d.%06dZ",
+	   tm.tm_year+1900,
+	   tm.tm_mon+1,
+	   tm.tm_mday,
+	   tm.tm_hour,
+	   tm.tm_min,
+	   tm.tm_sec,
+	   t_usec);
+
+  return result;
+}
+
 // Format a seconds count into hh:mm:ss
 char *ftime(char * result,int size,int64_t t){
   // Init to blanks

--- a/misc.h
+++ b/misc.h
@@ -132,7 +132,9 @@ extern char const *Months[12];
 
 int dist_path(char *path,int path_len,const char *fname);
 char *format_gpstime(char *result,int len,int64_t t);
+char *format_gpstime_iso8601(char *result,int len,int64_t t);
 char *format_utctime(char *result,int len,int64_t t);
+char *format_utctime_iso8601(char *result,int len,int64_t t);
 char *ftime(char *result,int size,int64_t t);
 void normalize_time(struct timespec *x);
 double parse_frequency(char const *,bool);

--- a/powers.c
+++ b/powers.c
@@ -200,7 +200,7 @@ int main(int argc,char *argv[]){
 
     // **************Process here ***************
     char gps[1024];
-    printf("%s,",format_gpstime(gps,sizeof(gps),time));
+    printf("%s,",format_gpstime_iso8601(gps,sizeof(gps),time));
 
     // Frequencies below center; note integer round-up, e.g, 65 -> 33; 64 -> 32
     // npower odd: emit N/2+1....N-1 0....N/2 (division truncating to integer)


### PR DESCRIPTION
This addresses issue 5 from #62.