### PR TITLE
Fix aviation config

### DIFF
--- a/config/radiod@aviation.conf
+++ b/config/radiod@aviation.conf
@@ -1,6 +1,5 @@
 [global]
-samprate = 24k
-mode = cam
+mode = amsq
 status = aviation.local
 hardware = airspy
 data = aviation-pcm.local
@@ -35,7 +34,6 @@ description = aviation VHF
 
 
 [MAIN]
-squelch = 10
 freq = "118m100 118m225 118m300 119m200 119m600 121m500 123m725 123m900 124m350 125m150 125m300 125m700 125m900 \
         125m975 126m900 127m300 128m600 128m625 132m200 133m475 134m800 135m200"
 	


### PR DESCRIPTION
The aviation config file references a mode that no longer exists (`cam`). It looks like `amsq` is intended for aviation AM signals, so I've switched to that. I also removed the `samprate` setting, which I believe is unnecessary, and the `squelch` setting, which doesn't seem to exist.