### PR TITLE
Fix spectrum demod bin level scaling

### DIFF
--- a/spectrum.c
+++ b/spectrum.c
@@ -84,10 +84,10 @@ int demod_spectrum(void *arg){
       for(int i=0; i < bin_count; i++){ // For each noncoherent integration bin above center freq
 	double p = 0;
 	for(int j=0; j < binsperbin; j++) // Add energy of each fft bin that's part of this user integration bin
-          p += gain * cnrmf(chan->filter.out.fdomain[binp++]);
+          p += cnrmf(chan->filter.out.fdomain[binp++]);
 
 	// Accumulate energy until next poll
-	chan->spectrum.bin_data[i] += p;
+	chan->spectrum.bin_data[i] += (p * gain);
       }
     }
   } while(downconvert(chan) == 0);

--- a/spectrum.c
+++ b/spectrum.c
@@ -79,10 +79,12 @@ int demod_spectrum(void *arg){
       chan->filter.min_IF = -chan->filter.max_IF;
     } else {
       int binp = 0;
+      float gain = (2.0 / (float) N);   // scale each bin value by 2/N (and hope N isn't 0!)
+      gain *= gain;                     // squared because the we're scaling the output of complex norm, not the input bin values
       for(int i=0; i < bin_count; i++){ // For each noncoherent integration bin above center freq
 	double p = 0;
 	for(int j=0; j < binsperbin; j++) // Add energy of each fft bin that's part of this user integration bin
-	  p += cnrmf(chan->filter.out.fdomain[binp++]);
+          p += gain * cnrmf(chan->filter.out.fdomain[binp++]);
 
 	// Accumulate energy until next poll
 	chan->spectrum.bin_data[i] += p;


### PR DESCRIPTION
Fairly confident on the 1/N scaling factor, less so on the 2. I did test with a function generator at various levels and with this fix powers, baseband, and ka9q-web outputs all matched to better than 1 dB.