### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
             libiniparser-dev \
             libavahi-client-dev \
             portaudio19-dev \
-            uuid-dev
+            uuid-dev \
+            libsamplerate0-dev
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup
@@ -57,7 +58,8 @@ jobs:
             librtlsdr \
             iniparser \
             portaudio \
-            dbus
+            dbus \
+            libsamplerate
 
           cd /tmp
           curl https://avahi.org/download/avahi-0.8.tar.gz > avahi-0.8.tar.gz

--- a/config.c
+++ b/config.c
@@ -6,6 +6,7 @@
 #include <iniparser/iniparser.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
 #include "config.h"
 
 


### PR DESCRIPTION
Needed to add libsamplerate, and MacOS wouldn't build unless config.c included string.h. This seems to be enough to make the boxes green again in my fork.