### PR TITLE
Workaround for the :59.x files created by pcmrecord in -L -j mode

### DIFF
--- a/pcmrecord.c
+++ b/pcmrecord.c
@@ -1028,7 +1028,6 @@ int session_file_init(struct session *sp,struct sockaddr const *sender){
   if (max_length > 0){
     sp->samples_remaining = max_length * sp->samprate;
   }
-  struct tm const * const tm = gmtime(&file_time.tv_sec);
   struct tm const *  tm = gmtime(&file_time.tv_sec);
   // yyyy-mm-dd-hh:mm:ss so it will sort properly
 #if 0


### PR DESCRIPTION
I'm seeing pcmrecord with the -j and -L flags create filenames that
are not an integer multiple of the -L FileLengthLimit value.

I've found a timespec that causes the issue and included it as a test
case with the PCMRECORD_TESTING #define.

For example, with now.tv_sec = 1737742319 and now.tv_nsec = 742568973,
the filename would have been 20250124T181159Z_15000000_iq.wav instead
of 20250124T181200Z_15000000_iq.wav.

(I think the section marked "Do time calculations with a modified epoch to avoid overflow problems" might be hitting an edge condition that's causing the filename error, but I'm scared to attack that section!)
