### PR TITLE
Switch back to ncursesw to fix UTF-8 encoding/display in control

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -27,7 +27,7 @@ LIBDIR=/usr/local/share/ka9q-radio
 SODIR=/usr/local/lib/ka9q-radio
 DAEMONDIR=/usr/local/sbin
 VARDIR=/var/lib/ka9q-radio
-LDLIBS=-ldl -lavahi-client -lavahi-common -lfftw3f_threads -lfftw3f -liniparser -lairspy -lairspyhf -lrtlsdr -lopus -logg -lportaudio -lasound -lusb-1.0 -lncurses -lbsd -lm -lpthread
+LDLIBS=-ldl -lavahi-client -lavahi-common -lfftw3f_threads -lfftw3f -liniparser -lairspy -lairspyhf -lrtlsdr -lopus -logg -lportaudio -lasound -lusb-1.0 -lncursesw -lbsd -lm -lpthread
 
 DAEMONS=aprs aprsfeed cwd opusd packetd radiod stereod rdsd
 


### PR DESCRIPTION
I don't know if there are any side effects, or why it was switched from ncursesw to ncurses in commit
fb63136d70ed0f05f65e650d3e1047bed55bc022. This patch does seem to fix the weird character display issue with control.