### PR TITLE
Link to Hombrew's ncurses in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,6 @@ jobs:
       - name: Setup
         run: ln -s Makefile.osx Makefile
       - name: Compile
-        run: C_INCLUDE_PATH="$(brew --prefix)/include" LIBRARY_PATH="$(brew --prefix)/lib" make
+        run: C_INCLUDE_PATH="$(brew --prefix)/include:$(brew --prefix)/opt/ncurses/include" LIBRARY_PATH="$(brew --prefix)/lib:$(brew --prefix)/opt/ncurses/lib" make
       - name: Install
         run: sudo make install


### PR DESCRIPTION
Fixes #105.

Homebrew's ncurses is a so-called "keg-only" package, which does not symlink into the usual locations to avoid overriding the system-provided ncurses package. Thus, we need to opt into using it by providing the correct paths to the compiler, which I've done here.