### PR TITLE
Split -march=native into a separate variable

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -17,10 +17,10 @@ ifeq ($(DYNAMIC),1)
      DOPTS += -DFORCE_DYNAMIC=1
 endif
 
-
+ARCHOPTS = -march=native
 # do NOT set -ffast-math or -ffinite-math-only; NANs are widely used as 'variable not set' sentinels
-COPTS = -march=native -std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1 -Wextra -MMD -MP
-CFLAGS = $(DOPTS) $(COPTS) $(INCLUDES)
+COPTS = -std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1 -Wextra -MMD -MP
+CFLAGS = $(DOPTS) $(ARCHOPTS) $(COPTS) $(INCLUDES)
 BINDIR = /usr/local/bin
 LIBDIR = /usr/local/share/ka9q-radio
 SODIR = /usr/local/lib/ka9q-radio


### PR DESCRIPTION
ka9q-radio builds with `-march=native`, presumably to maximize performance. This option is only safe to use when the code will be executed on the same machine where it is compiled. Auto-RX ships precompiled binaries which must run on any machine, so it needs to remove the `-march=native` option. At present, it does that by overriding the whole `COPTS` variable:

https://github.com/projecthorus/radiosonde_auto_rx/blob/35d951590db45be213e1a1eba8303324637460ae/Dockerfile#L65-L68

This is not ideal, since the override needs to be kept in sync with ka9q-radio's version. I think it would be useful to split this into its own variable, which I've done here. ka9q-radio can then be built portably with `make ARCHOPTS=`.