### PR TITLE
Widen the rate column

### DIFF
--- a/monitor-display.c
+++ b/monitor-display.c
@@ -684,7 +684,7 @@ static void update_monitor_display(void){
   // Data rate, kb/s
   if(x >= COLS)
     goto done;
-  width = 6;
+  width = 7;
   mvprintwt(y++,x,"%*s",width,"rate");
   for(int session = First_session; session < Nsessions_copy; session++,y++){
     struct session const *sp = Sessions_copy[session];


### PR DESCRIPTION
When receiving an FM stereo channel, the data rate is 1536.0 kb/s, which makes the rate column butt up against the pt column:

![Screenshot from 2025-02-10 23-14-29](https://github.com/user-attachments/assets/667b4fc4-762d-4ddf-b58c-d25d2d083d72)

Increasing the width to 7 solves the problem.