### PR TITLE
Remove zeroing of pthread_t

### DIFF
--- a/airspy.c
+++ b/airspy.c
@@ -291,7 +291,6 @@ int airspy_setup(struct frontend * const frontend,dictionary * const Dictionary,
 }
 int airspy_startup(struct frontend * const frontend){
   struct sdrstate * const sdr = (struct sdrstate *)frontend->context;
-  ASSERT_ZEROED(&sdr->monitor_thread,sizeof sdr->monitor_thread);
 #if 0
   // This should work, but it doesn't
   // So we set it in the first callback

--- a/airspyhf.c
+++ b/airspyhf.c
@@ -205,7 +205,6 @@ int airspyhf_setup(struct frontend * const frontend,dictionary * const Dictionar
 }
 int airspyhf_startup(struct frontend *frontend){
   struct sdrstate *sdr = (struct sdrstate *)frontend->context;
-  ASSERT_ZEROED(&sdr->monitor_thread,sizeof sdr->monitor_thread);
   pthread_create(&sdr->monitor_thread,NULL,airspyhf_monitor,sdr);
   return 0;
 }

--- a/aprsfeed.c
+++ b/aprsfeed.c
@@ -176,7 +176,6 @@ int main(int argc,char *argv[]){
     FILE *network = fdopen(Network_fd,"w+");
     setlinebuf(network);
     
-    ASSERT_ZEROED(&Read_thread,sizeof Read_thread);
     pthread_create(&Read_thread,NULL,netreader,NULL);
     
     // Log into the network

--- a/fobos.c
+++ b/fobos.c
@@ -441,7 +441,6 @@ static void rx_callback(float *buf, uint32_t len, void *ctx) {
 
 int fobos_startup(struct frontend *const frontend) {
   struct sdrstate *const sdr = (struct sdrstate *)frontend->context;
-  ASSERT_ZEROED(&sdr->monitor_thread,sizeof sdr->monitor_thread);
   pthread_create(&sdr->monitor_thread, NULL, fobos_monitor, sdr);
   fprintf(stdout, "fobos read thread running\n");
   return 0;

--- a/funcube.c
+++ b/funcube.c
@@ -322,7 +322,6 @@ int funcube_startup(struct frontend *frontend){
   assert(sdr != NULL);
 
   // Start processing A/D data
-  ASSERT_ZEROED(&sdr->proc_thread,sizeof sdr->proc_thread);
   pthread_create(&sdr->proc_thread,NULL,proc_funcube,sdr);
   fprintf(stdout,"funcube running\n");
   return 0;

--- a/main.c
+++ b/main.c
@@ -550,7 +550,6 @@ static int loadconfig(char const *file){
   if(Ctl_fd < 0){
     fprintf(stdout,"can't listen for commands from %s: %s; no control channel is set\n",Metadata_dest_string,strerror(errno));
   } else {
-    ASSERT_ZEROED(&Status_thread,sizeof Status_thread);
     if(Ctl_fd >= 3)
       pthread_create(&Status_thread,NULL,radio_status,NULL);
   }
@@ -558,7 +557,6 @@ static int loadconfig(char const *file){
   // Process individual demodulator sections in parallel for speed
   int const nsect = iniparser_getnsec(Configtable);
   pthread_t startup_threads[nsect];
-  memset(startup_threads,0,sizeof startup_threads); // Apparently necessary to prevent segfaults on pthread_join()
   int nthreads = 0;
   for(int sect = 0; sect < nsect; sect++){
     char const * const sname = iniparser_getsecname(Configtable,sect);
@@ -572,7 +570,6 @@ static int loadconfig(char const *file){
     if(config_getboolean(Configtable,sname,"disable",false))
       continue; // section is disabled
 
-    ASSERT_ZEROED(&startup_threads[nthreads],sizeof startup_threads[nthreads]);
     pthread_create(&startup_threads[nthreads++],NULL,process_section,(void *)sname);
   }
   // Wait for them all to start
@@ -730,7 +727,6 @@ void *process_section(void *p){
 	char sap_dest[] = "224.2.127.254:9875"; // sap.mcast.net
 	resolve_mcast(sap_dest,&chan->sap.dest_socket,0,NULL,0,0);
 	join_group(Output_fd,&chan->sap.dest_socket,iface);
-	ASSERT_ZEROED(&chan->sap.thread,sizeof chan->sap.thread);
 	pthread_create(&chan->sap.thread,NULL,sap_send,chan);
       }
       // RTCP Real Time Control Protocol daemon is optional
@@ -752,7 +748,6 @@ void *process_section(void *p){
 	  }
 	  break;
 	}
-	ASSERT_ZEROED(&chan->rtcp.thread,sizeof chan->rtcp.thread);
 	pthread_create(&chan->rtcp.thread,NULL,rtcp_send,chan);
       }
     }

--- a/metadump.c
+++ b/metadump.c
@@ -180,7 +180,6 @@ int main(int argc,char *argv[]){
   if(Verbose && Interval != 0)
     fprintf(stdout,"Polling %u interval %'.1f sec count %llu\n",(unsigned)Ssrc,(float)Interval * 1e-9,(long long)Count);
 
-  ASSERT_ZEROED(&Input_thread,sizeof Input_thread);
   pthread_create(&Input_thread,NULL,input_thread,NULL);
   if(Ssrc == 0){
     fprintf(stdout,"No ssrc specified, waiting passively for responses\n");

--- a/monitor-data.c
+++ b/monitor-data.c
@@ -128,7 +128,6 @@ void *dataproc(void *arg){
       sp->reset = true;
       sp->init = true;
 
-      ASSERT_ZEROED(&sp->task,sizeof sp->task);
       if(pthread_create(&sp->task,NULL,decode_task,sp) == -1){
 	perror("pthread_create");
 	close_session(&sp);

--- a/monitor.c
+++ b/monitor.c
@@ -390,9 +390,7 @@ int main(int argc,char * const argv[]){
   // All have to succeed in resolving their targets or we'll exit
   // This allows a restart when started automatically from systemd before avahi is fully running
   pthread_t datathreads[Nfds];
-  memset(datathreads,0,sizeof datathreads);
   pthread_t statthreads[Nfds];
-  memset(statthreads,0,sizeof statthreads);
   for(int i=0; i<Nfds; i++){
     pthread_create(&datathreads[i],NULL,dataproc,Mcast_address_text[i]);
     pthread_create(&statthreads[i],NULL,statproc,Mcast_address_text[i]);
@@ -404,7 +402,6 @@ int main(int argc,char * const argv[]){
   // Drove me up the wall trying to find out why this thread was spending so much CPU doing nothing!
   if(!Quiet){
     pthread_t display_thread;
-    memset(&display_thread,0,sizeof(display_thread));
     pthread_create(&display_thread,NULL,display,NULL);
   }
   while(!Terminate)

--- a/opusd.c
+++ b/opusd.c
@@ -356,7 +356,6 @@ int main(int argc,char * const argv[]){
 	sp->channels = channels;
 
 	// Span per-SSRC thread, each with its own instance of opus encoder
-	ASSERT_ZEROED(&sp->thread,sizeof sp->thread);
 	if(pthread_create(&sp->thread,NULL,encode,sp) == -1){
 	  perror("pthread_create");
 	  close_session(&sp);

--- a/packetd.c
+++ b/packetd.c
@@ -394,7 +394,6 @@ static void *input(void *arg){
 	}
 	sp->read_fd = fildes[0]; sp->write_fd = fildes[1];
 
-	ASSERT_ZEROED(&sp->decode_thread,sizeof sp->decode_thread);
 	pthread_create(&sp->decode_thread,NULL,decode_task,sp); // One decode thread per stream
 	if(Verbose){
 	  printtime(stdout);

--- a/radio.c
+++ b/radio.c
@@ -221,7 +221,6 @@ int start_demod(struct channel * chan){
     fprintf(stdout,"start_demod: ssrc %'u, output %s, demod %d, freq %'.3lf, preset %s, filter (%'+.0f,%'+.0f)\n",
 	    chan->output.rtp.ssrc, chan->output.dest_string, chan->demod_type, chan->tune.freq, chan->preset, chan->filter.min_IF, chan->filter.max_IF);
   }
-  ASSERT_ZEROED(&chan->demod_thread,sizeof chan->demod_thread);
   pthread_create(&chan->demod_thread,NULL,demod_thread,chan);
   return 0;
 }

--- a/rdsd.c
+++ b/rdsd.c
@@ -342,7 +342,6 @@ void *input(void *arg){
       sp->rtp_state_in.timestamp = pkt->rtp.timestamp;
 
       // Span per-SSRC thread
-      ASSERT_ZEROED(&sp->thread,sizeof sp->thread);
       if(pthread_create(&sp->thread,NULL,decode,sp) == -1){
 	perror("pthread_create");
 	close_session(sp);

--- a/rtlsdr.c
+++ b/rtlsdr.c
@@ -248,7 +248,6 @@ static void *rtlsdr_read_thread(void *arg){
 
 int rtlsdr_startup(struct frontend * const frontend){
   struct sdr * const sdr = frontend->context;
-  ASSERT_ZEROED(&sdr->read_thread,sizeof sdr->read_thread);
   pthread_create(&sdr->read_thread,NULL,rtlsdr_read_thread,sdr);
   fprintf(stdout,"rtlsdr thread running\n");
   return 0;

--- a/rx888.c
+++ b/rx888.c
@@ -361,9 +361,7 @@ int rx888_startup(struct frontend * const frontend){
   struct sdrstate * const sdr = (struct sdrstate *)frontend->context;
 
   // Start processing A/D data
-  ASSERT_ZEROED(&sdr->proc_thread, sizeof sdr->proc_thread);
   pthread_create(&sdr->proc_thread,NULL,proc_rx888,sdr);
-  ASSERT_ZEROED(&sdr->agc_thread, sizeof sdr->agc_thread);
   pthread_create(&sdr->agc_thread,NULL,agc_rx888,sdr);
   fprintf(stdout,"rx888 running\n");
   return 0;

--- a/sdrplay.c
+++ b/sdrplay.c
@@ -336,7 +336,6 @@ int sdrplay_setup(struct frontend * const frontend,dictionary * const Dictionary
 
 int sdrplay_startup(struct frontend * const frontend){
   struct sdrstate * const sdr = (struct sdrstate *)frontend->context;
-  ASSERT_ZEROED(&sdr->monitor_thread, sizeof sdr->monitor_thread);
   pthread_create(&sdr->monitor_thread,NULL,sdrplay_monitor,sdr);
   return 0;
 }

--- a/sig_gen.c
+++ b/sig_gen.c
@@ -308,7 +308,6 @@ int sig_gen_startup(struct frontend *frontend){
   assert(sdr != NULL);
 
   // Start processing A/D data
-  ASSERT_ZEROED(&sdr->proc_thread, sizeof(sdr->proc_thread));
   pthread_create(&sdr->proc_thread,NULL,proc_sig_gen,sdr);
   fprintf(stdout,"signal generator running\n");
   return 0;

--- a/stereod.c
+++ b/stereod.c
@@ -274,7 +274,6 @@ int main(int argc,char * const argv[]){
       sp->rtp_state_in.timestamp = pkt->rtp.timestamp;
 
       // Span per-SSRC thread
-      ASSERT_ZEROED(&sp->thread,sizeof sp->thread);
       if(pthread_create(&sp->thread,NULL,decode,sp) == -1){
 	perror("pthread_create");
 	close_session(&sp);


### PR DESCRIPTION
As far as I can tell, zeroing and zero-checking of `pthread_t` objects was added in an attempt to solve a threading bug (joining non-existent threads, which was later solved in fa1130f5165f0315ccc68b36f2f9f9d35b290d0a).

The zeroing doesn't really solve the bug, and just hides its presence. So I think ka9q-radio would be better off without it.