### PR TITLE
Improve stereo separation

### DIFF
--- a/share/presets.conf
+++ b/share/presets.conf
@@ -70,8 +70,8 @@ conj = no
 # wideband broadcast FM stereo. Output forced to 48 kHz stereo; defaults to North American de-emphasis time constants
 demod = wfm
 samprate = 384k
-low =  -100k
-high = +100k
+low =  -110k
+high = +110k
 threshold-extend = no ; not implemented
 deemph-tc = 75.0    # microseconds; change to 50.0 outside North America & Korea
 deemph-gain = 0.0   # dB, not necessary for WFM because of high corner frequency

--- a/wfm.c
+++ b/wfm.c
@@ -205,7 +205,7 @@ int demod_wfm(void *arg){
       for(int n = 0; n < audio_L; n++){
 	complex float subc_phasor = pilot.output.c[n]; // 19 kHz pilot
 	subc_phasor = (subc_phasor * subc_phasor) / cnrmf(subc_phasor); // square to 38 kHz and normalize
-	float subc_info = __imag__ (conjf(subc_phasor) * lminusr.output.c[n]); // Carrier is in quadrature
+	float subc_info = sqrtf(2) * __imag__ (conjf(subc_phasor) * lminusr.output.c[n]); // Carrier is in quadrature
 	assert(!isnan(subc_info));
 	assert(!isnan(mono.output.r[n]));
 	// demultiplex: 2L = (L+R) + (L-R); 2R = (L+R) - (L-R)

--- a/wfm.c
+++ b/wfm.c
@@ -89,7 +89,7 @@ int demod_wfm(void *arg){
   // FCC says +/- 2 Hz, with +/- 20 Hz protected (73.322)
   struct filter_out pilot;
   create_filter_output(&pilot,&composite,NULL,audio_L, COMPLEX);
-  set_filter(&pilot,-20./Audio_samprate, 20./Audio_samprate, chan->filter.kaiser_beta);
+  set_filter(&pilot,-100./Audio_samprate, 100./Audio_samprate, chan->filter.kaiser_beta);
 
   // Stereo difference (L-R) information on DSBSC carrier at 38 kHz
   // Extends +/- 15 kHz around 38 kHz


### PR DESCRIPTION
WFM stereo reception suffers from poor stereo separation (only about 14.7 dB). I believe the main reason is that the `lminusr` complex filter selects only one of the two (identical) sidebands of the real-valued composite signal, and therefore only gets half the power. Multiplying the output by sqrt(2) solves the problem, and improves stereo separation to 36.1 dB.