### PR TITLE
Add SANITIZE=1 option to makefile

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -13,6 +13,11 @@ else
      DOPTS = -DNDEBUG=1 -O3
 endif
 
+ifeq ($(SANITIZE),1)
+     DOPTS += -fsanitize=address -fsanitize=undefined
+     LDOPTS = -fsanitize=address -fsanitize=undefined
+endif
+
 ifeq ($(DYNAMIC),1)
      DOPTS += -DFORCE_DYNAMIC=1
 endif


### PR DESCRIPTION
Address Sanitizer (ASAN) and Undefined Behaviour Sanitizer (UBSAN) are useful for identifying bugs in C programs, and they found several of the bugs I have reported to ka9q-radio. So I thought it might be useful to add a `SANITIZE=1` option to the makefile so that others can easily use them.