### PR TITLE
Fix stereo subcarrier gain

### DIFF
--- a/stereod.c
+++ b/stereod.c
@@ -499,7 +499,7 @@ void *decode(void *arg){
 	  // zero PCM input would cause a divide-by-zero and a NAN result
 	  // that would poison the de-emphasis integrators if we didn't check for it
 	  subc_phasor /= a;
-	  left_minus_right = __imag__ (conjf(subc_phasor) * stereo.output.c[n]); // Carrier is in quadrature with modulation
+	  left_minus_right = 2.0f * __imag__ (conjf(subc_phasor) * stereo.output.c[n]); // Carrier is in quadrature with modulation
 	}
 	  
 	float left = mono.output.r[n] + left_minus_right; // left channel = L+R + L-R

--- a/wfm.c
+++ b/wfm.c
@@ -205,7 +205,7 @@ int demod_wfm(void *arg){
       for(int n = 0; n < audio_L; n++){
 	complex float subc_phasor = pilot.output.c[n]; // 19 kHz pilot
 	subc_phasor = (subc_phasor * subc_phasor) / cnrmf(subc_phasor); // square to 38 kHz and normalize
-	float subc_info = __imag__ (conjf(subc_phasor) * lminusr.output.c[n]); // Carrier is in quadrature
+	float subc_info = 2.0f * __imag__ (conjf(subc_phasor) * lminusr.output.c[n]); // Carrier is in quadrature
 	assert(!isnan(subc_info));
 	assert(!isnan(mono.output.r[n]));
 	// demultiplex: 2L = (L+R) + (L-R); 2R = (L+R) - (L-R)


### PR DESCRIPTION
As explained in https://github.com/ka9q/ka9q-radio/pull/115#issuecomment-2653519666, a gain of 2 must be applied to the L-R subcarrier after demodulation. With this change in place, stereo separation returns to ~40 dB.