### PR TITLE
Fix CI build for CMake 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
           cd onion
           mkdir build
           cd build
-          cmake -DONION_USE_PAM=false -DONION_USE_PNG=false \
+          cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DONION_USE_PAM=false -DONION_USE_PNG=false \
             -DONION_USE_JPEG=false -DONION_USE_XML2=false \
             -DONION_USE_SYSTEMD=false -DONION_USE_SQLITE3=false \
             -DONION_USE_REDIS=false -DONION_USE_GC=false \


### PR DESCRIPTION
CI builds began failing when the GitHub Actions runner updated to CMake 4, which requires `cmake_minimum_required` to be set to 3.5 or higher. The "onion" dependency specifies 2.8:

```
Cloning into 'onion'...
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```

Here I've added the suggested override, and the CI run now passes.