### PR TITLE
Fix spectrum bin level so it doesn't vary with bin width

### DIFF
--- a/spectrum.c
+++ b/spectrum.c
@@ -188,7 +188,7 @@ int demod_spectrum(void *arg){
 	  outf += ratio;
 	  count++;
 	}
-	chan->spectrum.bin_data[out++] = (p * gain) / count;
+	chan->spectrum.bin_data[out++] = (p * gain);
       }
       // Positive output frequencies
       out = 0;
@@ -202,7 +202,7 @@ int demod_spectrum(void *arg){
 	  outf += ratio;
 	  count++;
 	}
-	chan->spectrum.bin_data[out++] = (p * gain) / count;
+	chan->spectrum.bin_data[out++] = (p * gain);
       }
     } else {
       // ***FFT MODE***


### PR DESCRIPTION
The bin power seems to vary based on bin width. I'm testing with an arb set to 2.5 MHz at ranges from -50 to -10 dBm, and I see the baseband and spectrum power match only when bin width is 40 Hz. Wider bins show less power. Removing the scale by bin count factor seems to fix this. Or it's closer--the baseband and powers readings now match.