### PR TITLE
Include "ssrc" key in list of valid channel keys.

### DIFF
--- a/modes.c
+++ b/modes.c
@@ -105,6 +105,7 @@ char const *Channel_keys[] = {
   "freq7",
   "freq8",
   "freq9",
+  "ssrc",
   NULL
 };
 


### PR DESCRIPTION
I was getting a "key "ssrc" not found" warning at startup. This seems to suppress it.