### PR TITLE
add doc target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,6 @@ wd-record
 work
 wspr-decoded
 docs/notes
-
+html/
+latex/
+man/

--- a/Doxyfile
+++ b/Doxyfile
@@ -53,7 +53,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = KA9Q multichannel SDR packagea
+PROJECT_BRIEF          = KA9Q multichannel SDR package
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -906,7 +906,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ..
+INPUT                  =
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1117,7 +1117,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.

--- a/Makefile.jonsnow
+++ b/Makefile.jonsnow
@@ -1,0 +1,42 @@
+PKG_NAME = ka9q-radio
+USR_LIB = /usr/local/lib/$(PKG_NAME)
+USR_SHR = /usr/local/share/$(PKG_NAME)
+VAR_LIB = /var/lib/$(PKG_NAME)
+ETC_FFTW = /etc/fftw
+MY_CFG = bp_config
+
+wisdom:
+	fftwf-wisdom -c -T $(shell nproc) -t 0.004 -o ./wisdom-start 
+	fftwf-wisdom -v -T $(shell nproc) -w ./wisdom-start -o ./wisdomf cof45000 cob9600 rof15360 rob1920 cob1920 cob600 cob300 cob5
+	#fftwf-wisdom -v -T 1 -w $(VAR_LIB)/wisdom -o ./wisdomf cof45000 cob9600 rof15360 rob1920 cob1920 cob600 cob300
+
+install:
+	sudo setcap "cap_sys_nice,cap_net_admin=+ep" ./radiod
+	sudo getcap ./radiod
+	sudo setcap "cap_sys_nice=+ep" ./monitor
+	sudo getcap ./monitor
+	sudo mkdir -p $(USR_LIB)
+	#sudo chown -R $(USER):$(USER) $(USR_LIB)
+	sudo rm -f $(USR_LIB)/*so
+	sudo cp -f ./*so $(USR_LIB)
+	sudo mkdir -p $(USR_SHR)
+	sudo chmod a+w $(USR_SHR)
+	cp -f share/presets.conf $(USR_SHR)
+	cp -f share/monitor-help.txt $(USR_SHR)
+	if [ -f $(MY_CFG)/id.txt ]; then \
+		cp -f $(MY_CFG)/id.txt $(USR_SHR); \
+	fi
+	sudo chmod ga+w $(USR_SHR)/*
+	sudo mkdir -p $(VAR_LIB)
+	sudo chmod a+wx $(VAR_LIB)
+	if [ -f ./wisdomf ]; then \
+		sudo mkdir -p $(ETC_FFTW); \
+		sudo cp -f ./wisdomf $(ETC_FFTW); \
+	fi
+
+uninstall:
+	sudo rm -rvf $(USR_LIB)
+	sudo rm -rvf $(USR_SHR)
+	sudo rm -rvf $(VAR_LIB)
+
+.PHONY: install uninstall wisdom

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -140,11 +140,15 @@ endif
 clean:
 	-rm -f *.o *.a *.d *.so $(DAEMONS) $(EXECS) $(DYNAMIC_DRIVERS) $(STATIC_DRIVERS)
 
+doc:
+	rm -rf html latex man
+	doxygen
+
 DEPS = $(CFILES:.c=.d)
 
 -include $(DEPS)
 
-.PHONY: clean all install pi dynamics
+.PHONY: clean all install doc dynamics
 
 dynamics: $(DYNAMIC_DRIVERS)
 

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -32,13 +32,18 @@ install: $(EXECS)
 clean:
 	rm -f *.o *.a *.d .depend $(EXECS)
 
+doc:
+	rm -rf html latex man
+	doxygen
+
 DEPS = $(CFILES:.c=.d)
 
 -include $(DEPS)
 
-.PHONY: clean all install
+.PHONY: clean all install doc
 
 # Executables
+
 aprs: aprs.o libradio.a
 	$(CC) -g -o $@ $^ -lm
 

--- a/pcmrecord.c
+++ b/pcmrecord.c
@@ -1,5 +1,5 @@
 /**
-@file pcmrecord.c
+@file
 @author Phil Karn, KA9Q
 @brief Record, stream, or launch commands with RTP streams as input
 @verbatim

--- a/rtlsdr.c
+++ b/rtlsdr.c
@@ -1,6 +1,14 @@
-// Built-in driver for RTL-SDR in radiod
-// Adapted from old rtlsdrd.c
-// Copyright July 2023, Phil Karn, KA9Q
+/**
+ * @file
+ * @author Phil Karn, KA9Q
+ * @brief device driver for RTL-SDR
+ * @copyright 2023
+ * @verbatim
+ * Built-in driver for RTL-SDR in radiod
+ * Adapted from old rtlsdrd.c
+ * @endverbatim
+**/
+
 #define _GNU_SOURCE 1
 #include <assert.h>
 #include <pthread.h>


### PR DESCRIPTION
Added a first functional Doxygen target to the Makefiles. Please be aware that I am not using OSX so I could not test that part.

The current Doxygen configuration generates some html docs, but you may need to add some standard comment header to each important source file. Please look at pcmrecord.c and rtlsdr.c for existing ones and let me know ...