### PR TITLE
Change wide spectrum bin summing loop from FP to int

### DIFF
--- a/spectrum.c
+++ b/spectrum.c
@@ -176,52 +176,12 @@ int demod_spectrum(void *arg){
       float ratio = (float)bin_count / input_bins;
 
       int out = bin_count/2;
+      float outf;
       int in = 0;
-      float outf = out;
-      if (chan->options & 1){
-         fprintf(stderr,"ratio: %.6f bin_count: %d input_bins: %d out: %d in: %d\n",
-                 ratio,
-                 bin_count,
-                 input_bins,
-                 out,
-                 in);
-      }
       while(out < bin_count && in < input_bins){
-         float p = 0;
-         outf = out;
-         int x = 0;
-         if (chan->options & 1){
-            fprintf(stderr,"out: %d in: %d outf: %.6f\n",
-                    out,
-                    in,
-                    outf);
-         }
-         while((int)outf == out && in < input_bins){
-	  assert(in >= 0 && in < input_bins);
-	  p += power_buffer[in++];
-          outf = (++x * ratio) + out;
-	}
-	chan->spectrum.bin_data[out++] = (p * gain);
-      }
-      if (chan->options & 1){
-         fprintf(stderr,"end out: %d in: %d outf: %.6f\n",
-                 out,
-                 in,
-                 outf);
-      }
-      // Positive output frequencies
-      out = 0;
-      in = input_bins/2;
-      while(out < bin_count/2 && in < input_bins){
-        float p = 0;
+	float p = 0;
         outf = out;
         int x = 0;
-        if (chan->options & 1){
-           fprintf(stderr,"out: %d in: %d outf: %.6f\n",
-                   out,
-                   in,
-                   outf);
-        }
 	while((int)outf == out && in < input_bins){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
@@ -229,13 +189,20 @@ int demod_spectrum(void *arg){
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
       }
-      if (chan->options & 1){
-         fprintf(stderr,"end out: %d in: %d outf: %.6f\n",
-                 out,
-                 in,
-                 outf);
+      // Positive output frequencies
+      out = 0;
+      in = input_bins/2;
+      while(out < bin_count/2 && in < input_bins){
+	float p = 0;
+        outf = out;
+        int x = 0;
+	while((int)outf == out && in < input_bins){
+	  assert(in >= 0 && in < input_bins);
+	  p += power_buffer[in++];
+          outf = (++x * ratio) + out;
+	}
+	chan->spectrum.bin_data[out++] = (p * gain);
       }
-      chan->options &= (~1);
     } else {
       // ***FFT MODE***
 

--- a/spectrum.c
+++ b/spectrum.c
@@ -173,29 +173,69 @@ int demod_spectrum(void *arg){
 	  power_buffer[i++] = 0;
       }
       // Merge the bins, negative output frequencies first
-      int ratio = input_bins / bin_count;
+      float ratio = (float)bin_count / input_bins;
 
       int out = bin_count/2;
       int in = 0;
+      float outf = out;
+      if (chan->options & 1){
+         fprintf(stderr,"ratio: %.6f bin_count: %d input_bins: %d out: %d in: %d\n",
+                 ratio,
+                 bin_count,
+                 input_bins,
+                 out,
+                 in);
+      }
       while(out < bin_count && in < input_bins){
-	float p = 0;
-        for(int i = 0; i < ratio; ++i){
+         float p = 0;
+         outf = out;
+         int x = 0;
+         if (chan->options & 1){
+            fprintf(stderr,"out: %d in: %d outf: %.6f\n",
+                    out,
+                    in,
+                    outf);
+         }
+         while((int)outf == out && in < input_bins){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
+          outf = (++x * ratio) + out;
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
+      }
+      if (chan->options & 1){
+         fprintf(stderr,"end out: %d in: %d outf: %.6f\n",
+                 out,
+                 in,
+                 outf);
       }
       // Positive output frequencies
       out = 0;
       in = input_bins/2;
       while(out < bin_count/2 && in < input_bins){
-	float p = 0;
-        for(int i = 0; i < ratio; ++i){
+        float p = 0;
+        outf = out;
+        int x = 0;
+        if (chan->options & 1){
+           fprintf(stderr,"out: %d in: %d outf: %.6f\n",
+                   out,
+                   in,
+                   outf);
+        }
+	while((int)outf == out && in < input_bins){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
+          outf = (++x * ratio) + out;
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
       }
+      if (chan->options & 1){
+         fprintf(stderr,"end out: %d in: %d outf: %.6f\n",
+                 out,
+                 in,
+                 outf);
+      }
+      chan->options &= (~1);
     } else {
       // ***FFT MODE***
 

--- a/spectrum.c
+++ b/spectrum.c
@@ -173,30 +173,26 @@ int demod_spectrum(void *arg){
 	  power_buffer[i++] = 0;
       }
       // Merge the bins, negative output frequencies first
-      float ratio = (float)bin_count / input_bins;
+      int ratio = input_bins / bin_count;
 
       int out = bin_count/2;
-      float outf = (int)out;
       int in = 0;
       while(out < bin_count && in < input_bins){
 	float p = 0;
-	while((int)outf == out && in < input_bins){
+        for(int i = 0; i < ratio; ++i){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
-	  outf += ratio;
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
       }
       // Positive output frequencies
       out = 0;
-      outf = (int)out;
       in = input_bins/2;
       while(out < bin_count/2 && in < input_bins){
 	float p = 0;
-	while((int)outf == out && in < input_bins){
+        for(int i = 0; i < ratio; ++i){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
-	  outf += ratio;
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
       }


### PR DESCRIPTION
Not well tested. Concerned I may have broken something in the process. I know this is hot code, so I'm also concerned this patch might be slower. Please review with care!

With a 13.56 MHz signal, I was seeing the ka9q-web waveform peak incorrectly placed at 16 kHz/bin spans and wider. Output from powers also affected.

Before:
8 kHz/bin: peak in bin 1290 at 13560000 Hz, -69.16 dBm 16 kHz/bin: bin 1445 at 13400000 Hz (!), -69.25 dBm

After:
8 kHz/bin: bin 1290 at 13560000 Hz, -69.44 dBm
16 kHz/bin: bin 1455 at 13560000 Hz, -69.15 dBm