### PR TITLE
Attempt to improve spectrum.c bin summing loop

### DIFF
--- a/spectrum.c
+++ b/spectrum.c
@@ -178,28 +178,28 @@ int demod_spectrum(void *arg){
       int out = bin_count/2;
       float outf;
       int in = 0;
+      outf = out;
+      int x = 0;
       while(out < bin_count && in < input_bins){
 	float p = 0;
-        outf = out;
-        int x = 0;
 	while((int)outf == out && in < input_bins){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
-          outf = (++x * ratio) + out;
+          outf = (++x * ratio) + (bin_count/2);
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
       }
       // Positive output frequencies
       out = 0;
       in = input_bins/2;
+      outf = out;
+      x = 0;
       while(out < bin_count/2 && in < input_bins){
 	float p = 0;
-        outf = out;
-        int x = 0;
 	while((int)outf == out && in < input_bins){
 	  assert(in >= 0 && in < input_bins);
 	  p += power_buffer[in++];
-          outf = (++x * ratio) + out;
+          outf = (++x * ratio);
 	}
 	chan->spectrum.bin_data[out++] = (p * gain);
       }


### PR DESCRIPTION
The "(++x * ratio)" should avoid accumulating floating point roundoff error in the summing loop, as before.

Instead of resetting the outf variable with each output bin, let it accumulate from the starting input bin. I think this will allow for weird bin in/out ratios, where some output bins might have one more or one less input bin.

I couldn't come up with a clean test case to show the difference, because the binsperbin and input_bins calculation was fighting me. So I hacked the input_bins count to force the issue, and I did see output bins with a variable number of input bins:

out: 810 in: 0 outf: 810.000000
out: 811 in: 494 outf: 811.000366
out: 812 in: 988 outf: 812.000671
out: 813 in: 1482 outf: 813.001038
out: 814 in: 1976 outf: 814.001343
out: 815 in: 2470 outf: 815.001709
out: 816 in: 2963 outf: 816.000000
out: 817 in: 3457 outf: 817.000366

I think there may still be an off by one issue lurking when the output bin count is odd.