### PR TITLE
Add some git info to VERSION macro

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,20 @@ LDFLAGS  ?=
 
 LDLIBS = -lm -lpthread
 
+GIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_TIME := $(shell git show -s --format=%ci 2>/dev/null || echo "unknown")
+GIT_BRANCH := $(shell git log --pretty=format:'%d' -n 1 2>/dev/null || echo "unknown")
+GIT_SUMMARY := $(shell git log -1 --format="%s" 2>/dev/null || echo "unknown")
+GIT_VERSION := $(shell git describe --always --dirty --tags 2>/dev/null || echo "unknown")
+GIT_REMOTE_URL := $(shell git remote get-url origin 2>/dev/null || echo "unknown")
+
+VERSION_FLAGS = -DGIT_HASH='"$(GIT_HASH)"' \
+                -DGIT_TIME='"$(GIT_TIME)"' \
+                -DGIT_BRANCH='"$(GIT_BRANCH)"' \
+                -DGIT_SUMMARY='"$(GIT_SUMMARY)"' \
+                -DGIT_VERSION='"$(GIT_VERSION)"' \
+                -DGIT_REMOTE_URL='"$(GIT_REMOTE_URL)"'
+
 ifeq ($(UNAME_S),Darwin)
   CPPFLAGS += -I/opt/local/include
   LDFLAGS  += -L/opt/local/lib
@@ -39,7 +53,7 @@ ARCHOPTS = -march=native
 # do NOT set -ffast-math or -ffinite-math-only; NANs are widely used as 'variable not set' sentinels
 COPTS = -std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -freciprocal-math -fno-trapping-math -D_GNU_SOURCE=1 -Wextra -Wno-sign-conversion -Wno-int-conversion -MMD -MP
 COPTS += -fPIC
-CFLAGS = $(DOPTS) $(ARCHOPTS) $(COPTS) $(INCLUDES)
+CFLAGS = $(DOPTS) $(ARCHOPTS) $(COPTS) $(INCLUDES) $(VERSION_FLAGS)
 BINDIR = /usr/local/bin
 SODIR = /usr/local/lib/ka9q-radio
 DAEMONDIR = /usr/local/sbin

--- a/src/misc.h
+++ b/src/misc.h
@@ -27,8 +27,14 @@
 
 // Must be a macro so __FILE__ and __TIMESTAMP__ will substitute correctly
 #define VERSION() { fprintf(stderr,"KA9Q Multichannel SDR %s last modified %s\n",__FILE__,__TIMESTAMP__); \
-		    fprintf(stderr,"Copyright 2025, Phil Karn, KA9Q. May be used under the terms of the GNU Public License\n");}
-
+  fprintf(stderr,"Copyright 2026, Phil Karn, KA9Q. May be used under the terms of the GNU Public License\n"); \
+  fprintf(stderr,"   Repo: %s\n",GIT_REMOTE_URL); \
+  fprintf(stderr," Commit: %s\n",GIT_HASH); \
+  fprintf(stderr,"   Date: %s\n",GIT_TIME); \
+  fprintf(stderr," Branch:%s\n",GIT_BRANCH); \
+  fprintf(stderr,"Version: %s\n",GIT_VERSION); \
+  fprintf(stderr,"Summary: %s\n",GIT_SUMMARY); \
+}
 
 #define ASSERT_ZEROED(ptr, size) assert(memcmp(ptr, &(typeof(*(ptr))){0}, size) == 0)
 


### PR DESCRIPTION
With this in place, here's an example of the startup log:

KA9Q Multichannel SDR main.c last modified Fri Jan  9 22:16:25 2026 Copyright 2026, Phil Karn, KA9Q. May be used under the terms of the GNU Public License
   Repo: https://github.com/scottnewell/ka9q-radio.git
 Commit: 358d233306902b1b91cbf7d77bfce746770299b1
   Date: 2026-01-10 05:05:58 +0000
 Branch: (HEAD, origin/hack_utah)
Version: v0.1-1555-g358d233
Summary: Testing at KD7EFG

(Also bumping the copyright date to 2026!)