### PR TITLE
Cast to a 'float' was causing a dropping of right channel audio when a stereo signal was present for wfm

### DIFF
--- a/src/wfm.c
+++ b/src/wfm.c
@@ -253,7 +253,7 @@ int demod_wfm(void *arg){
 	if(fm_rate != 0)
 	  s = stereo_deemph += fm_rate * (fm_gain * s - stereo_deemph);
 
-	stereo_buffer[n] = (float)(s * gain);
+	stereo_buffer[n] = (float complex)(s * gain);
 	output_energy += cnrmf(stereo_buffer[n]);
       }
       // Halve power to get level per channel


### PR DESCRIPTION
For WFM, it looks like right channel audio was getting dropped because of the cast to a ‘float’ instead of ‘float complex’.