### PR TITLE
fix: Check hp->frame_bits > 7 before the subtraction

### DIFF
--- a/src/packetd.c
+++ b/src/packetd.c
@@ -640,13 +640,15 @@ static int hdlc_process(struct hdlc *hp,int bit){
   
   if((hp->last_bits & 0xff) == 0x7e){
     // 01111110 - Flag
-    int const bytes = (hp->frame_bits - 7) >> 3; // Don't count leading 7 bits of flag
-    if(hp->flag_seen && bytes > 2){
-      hp->frame_bits = 0;
-      if(crc_good(hp->frame,bytes)){
-	return bytes; // Caller must set frame_bits to 0 when done
-      } else
-	return -1;
+    if(hp->flag_seen && hp->frame_bits > 7){
+      int const bytes = (hp->frame_bits - 7) >> 3; // Don't count leading 7 bits of flag
+      if(bytes > 2){
+	hp->frame_bits = 0;
+	if(crc_good(hp->frame,bytes)){
+	  return bytes; // Caller must set frame_bits to 0 when done
+	} else
+	  return -1;
+      }
     }
     hp->frame_bits = 0;
     hp->flag_seen = 1;


### PR DESCRIPTION
I've been running your, frankly, amazing tooling with my rx888 for a few days and I'm gobsmacked at how useful it is.  Thank you, genuinely, for your desire to create something like this!

I stumbled on a segmentation fault in packetd while trying to decode aprs packets.  I fed the failure into claude, since I am by no means a C wizard, and it said:

>   Bug: hp->frame_bits is unsigned. With frame_bits < 7, the expression (hp->frame_bits - 7) underflows to ~`0xFFFFFFF9, which after >> 3 becomes 536870911— a large
  positive int that passes the bytes > 2 guard then tries to read ~536 MB from a 16 KB buffer.

>  Trigger: Back-to-back HDLC flags (0x7e 0x7e), or any input that causes a flag to be detected when fewer than 7 bits have been accumulated in the frame since the last flag.

>  Fix: Check hp->frame_bits > 7 before the subtraction, so the underflow can never happen. The subtraction and the crc_good call are now inside that guard.

I do not presume to believe that this fix is the "best fix for you" and if you would like to correct this issue in a different way, please take my PR as a suggestion only.

Here's the gdb output.
```
Thread 3 "afsk" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff6ffe6c0 (LWP 362595)]
crc_good (frame=0x7ffff0021001 "", length=536738802) at ax25.c:145
145         uint8_t byte = *frame++;
(gdb)
(gdb)
(gdb) list
140     int crc_good(uint8_t *frame,size_t length){
141       unsigned int const crc_poly = 0x8408;
142
143       uint16_t crc = 0xffff;
144       while(length-- > 0){
145         uint8_t byte = *frame++;
146         for(int i=0; i < 8; i++){
147           uint16_t feedback = 0;
148           if((crc ^ byte) & 1)
149             feedback = crc_poly;
```
