### PR TITLE
fix: the memcpy at ax25 in ax25.c

### DIFF
--- a/src/ax25.c
+++ b/src/ax25.c
@@ -200,6 +200,9 @@ int ax25_parse(struct ax25_frame *out,uint8_t const *in,size_t len){
   }
   out->control = in[ctl_offs];
   out->type = in[ctl_offs+1];
+
+  if(len < ctl_offs + 4) // need ctl, type, and 2 CRC bytes minimum
+    return -1;
   out->info_len = len - (ctl_offs+2) - 2; // drop ctl/type before, crc after
 
   if(out->info_len > sizeof(out->information))


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/ax25.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/ax25.c:208` |

**Description**: The memcpy at ax25.c:208 copies out->info_len bytes from an incoming AX.25 packet buffer into the heap-allocated out->information buffer without verifying that out->info_len does not exceed the destination buffer's allocated size. The info_len value is derived directly from the attacker-controlled packet, meaning any remote party that can send AX.25 packets (over RF or a network feed) can set info_len to an arbitrarily large value and overflow the heap buffer, corrupting adjacent heap metadata or function pointers.

## Changes
- `src/ax25.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
