### PR TITLE
fix RADIO_FREQUENCY / RESOLUTION_BW TLV type mismatches

### DIFF
--- a/src/powers.c
+++ b/src/powers.c
@@ -157,7 +157,7 @@ int main(int argc,char *argv[]){
     encode_int(&bp,COMMAND_TAG,tag);
     encode_int(&bp,DEMOD_TYPE,SPECT_DEMOD);
     if(frequency >= 0)
-      encode_float(&bp,RADIO_FREQUENCY,frequency); // 0 frequency means terminate
+      encode_double(&bp,RADIO_FREQUENCY,frequency); // 0 frequency means terminate
     if(bins > 0)
       encode_int(&bp,BIN_COUNT,bins);
     if(rbw > 0)
@@ -353,7 +353,7 @@ int extract_powers(float *power,int npower,uint64_t *time,double *freq,double *r
       }
       break;
     case RESOLUTION_BW:
-      *rbw = decode_double(cp,optlen);
+      *rbw = decode_float(cp,optlen);
       break;
     case BIN_COUNT: // Do we check that this equals the length of the BIN_DATA tlv?
       l_ccount = decode_int(cp,optlen);


### PR DESCRIPTION
## Problem

`powers` returns an unusable spectrum: untuned (centered at DC regardless of
`-f`) with a collapsed frequency axis, so the printed start/stop/bin-width are
wrong and the bins don't correspond to the requested band.

## Root cause

Two TLV encode/decode type mismatches between `powers` and `radiod`:

1. **`RADIO_FREQUENCY` sent as float.** `powers` encoded the tune frequency
   with `encode_float` (`powers.c`), but `radiod` decodes the command's
   `RADIO_FREQUENCY` as a **double** (`radio_status.c`, `decode_double`).
   `control.c` already sends it as `encode_double`. The float value was
   misread, the channel was left untuned (~0 Hz), and the result was a
   baseband/DC spectrum.

2. **`RESOLUTION_BW` decoded as double.** `radiod` encodes the spectrum
   status `RESOLUTION_BW` as a **float** (`radio_status.c`, `encode_float`),
   but `extract_powers` decoded it with `decode_double`, collapsing the
   reported start/stop/width.

## Scope / testing

These are command/status format fixes only — they do not touch the
spectrum bin reordering / orientation, so they are independent
of front-end type.

Verified hardware-free with `sig_gen` in both `real` and `complex` modes. A
CW carrier at 10 MHz is reported by `powers` at 10 MHz and tracks `-f`;
before the patch it collapses to DC with a broken axis.

### Reproduction (no SDR hardware)

`siggen-test.conf`:

```ini
[global]
hardware = sig_gen
status = sgtest.local
data = sgdata.local
samprate = 12k
mode = usb

[sig_gen]
device = sig_gen
description = "powers regression - CW carrier"
carrier = 10m0      # pure carrier at exactly 10 MHz
amplitude = -20     # dBFS
noise = -60         # low floor so the carrier is unambiguous
samprate = 30m0
modulation = CW
real = y            # second run: comment out `real`, enable `complex = y`
```

```bash
make -C src -j"$(nproc)" radiod powers sig_gen.so
radiod siggen-test.conf &
sleep 6
# (1) tuned ON the carrier:
powers -c 1 -i 2 -s 12345 -f 10000000 -w 2000 -b 1000 sgtest.local > on.csv
# (2) tuned 500 kHz BELOW (carrier must STILL report 10 MHz):
powers -c 1 -i 2 -s 12345 -f  9500000 -w 2000 -b 1000 sgtest.local > off.csv
```

### Pass check

```bash
awk -F', *' 'NF>6{start=$2; bw=$4; n=$5; mx=-1e9; k=0;
  for(i=6;i<6+n;i++) if($i+0>mx){mx=$i+0; k=i-6}
  printf "peak at %.3f MHz (%.1f dB), header span %.3f-%.3f MHz, bw %.0f Hz, nbins %d\n",
         (start+k*bw)/1e6, mx, start/1e6, $3/1e6, bw, n}' on.csv off.csv
```

### Results

**Patched** (`real` front end):
```
on.csv     peak at 10.000 MHz (-20.0 dB), header span 9.000-10.998 MHz, bw 2000 Hz, nbins 1000
off.csv    peak at 10.000 MHz (-20.0 dB), header span 8.500-10.498 MHz, bw 2000 Hz, nbins 1000
```

**Patched** (`complex` front end): identical — peak at 10.000 MHz in both runs.

In the `off` run (tuned to 9.5 MHz) the carrier is reported at its true
10 MHz, i.e. it tracks the requested band, not `-f`.

**Unmodified `main`** (same radiod, same commands):
```
peak at 0.000 MHz, header span -0.000-0.000 MHz, bw 0 Hz, nbins 1000
peak at 0.000 MHz, header span -0.000-0.000 MHz, bw 0 Hz, nbins 1000
```
i.e. the carrier collapses to DC and the axis is collapsed (bw 0),
independent of `-f`.

This covers `real` and `complex` empirically. I have not synthesized a
*real-inverted* front end — `sig_gen` is right-side-up only — but the
orientation reorder (the `first_neg_bin` fftshift in `main()`) is exactly the
code this PR leaves untouched, so the carrier-frequency check is identical
regardless of inversion.