### PR TITLE
rx888: fix wedge-detection bug and add in-driver FX3 recovery escalation

### DIFF
--- a/src/rx888.c
+++ b/src/rx888.c
@@ -95,7 +95,12 @@ struct sdrstate {
   unsigned int transfer_index; // Write index into the transfer_size array (unused)
   struct libusb_transfer **transfers; // List of transfer structures.
   unsigned char **databuffers;        // List of data buffers.
-  long long last_callback_time;
+  long long last_callback_time;       // ns timestamp of last *successful* bulk transfer carrying data
+
+  // Tiered mid-stream wedge recovery — see commit message for analysis.
+  // 0 = idle, 1 = Tier-1a fired (STOPFX3+STARTFX3), 2 = Tier-1b fired (RESETFX3)
+  int recovery_tier;
+  long long recovery_grace_until;     // ns; while in tier-1a, suppress further watchdog action until this time
 
   // USB transfer
   int xfers_in_progress;
@@ -501,11 +506,35 @@ static void *proc_rx888(void *arg){
    }
     // But also check for a silent hang with libusb_handle_events_timeout_completed()
     // Check more directly how long it's been since we last got data
-    // sdr->last_callback_time is set in rx_callback()
+    // sdr->last_callback_time is set in rx_callback() *only* on a successful, non-empty transfer.
     int const maxtime = 5;
-    if(gps_time_ns() > sdr->last_callback_time + maxtime * BILLION){
-      fprintf(stderr,"No rx888 data for %d seconds, quitting\n",maxtime);
-      break;
+    int64_t const now_ns = gps_time_ns();
+    if(now_ns > sdr->last_callback_time + maxtime * BILLION){
+      // Wedge detected. Escalate through FX3 vendor-command tiers before giving up.
+      // See ExtIO_sddc/SDDC_FX3/USBhandler.c for the firmware-side definitions.
+      // Tier-1a (STOPFX3+STARTFX3): resets the FX3 DMA channel + GPIF SW input, in-stream,
+      //                             ~0.5 s, no USB re-enumeration.
+      // Tier-1b (RESETFX3):         full FX3 soft reset; USB re-enumerates via bootloader +
+      //                             fxload; we must exit and let the supervisor restart us.
+      if(sdr->recovery_tier == 0) {
+        fprintf(stderr,"No rx888 data for %d seconds — Tier-1a (STOPFX3+STARTFX3)\n", maxtime);
+        command_send(sdr->dev_handle, STOPFX3, 0);
+        usleep(500000);   // 500 ms
+        command_send(sdr->dev_handle, STARTFX3, 0);
+        sdr->recovery_tier = 1;
+        sdr->recovery_grace_until = now_ns + 30LL * BILLION;   // 30 s for data to resume
+        sdr->last_callback_time = now_ns;                      // reset watchdog
+      } else if(sdr->recovery_tier == 1 && now_ns > sdr->recovery_grace_until) {
+        fprintf(stderr,"rx888 wedge persists after Tier-1a — Tier-1b (RESETFX3), exiting for supervisor restart\n");
+        command_send(sdr->dev_handle, RESETFX3, 0);
+        exit(EX_NOINPUT);
+      } else if(sdr->recovery_tier == 1) {
+        // Still in grace period — keep pumping libusb events and hope for data
+      } else {
+        // recovery_tier >= 2 — shouldn't be reachable since tier-1b exits, but be safe
+        fprintf(stderr,"No rx888 data for %d seconds, quitting\n", maxtime);
+        break;
+      }
     }
     struct timeval tv;
     tv.tv_sec = 1;
@@ -594,7 +623,9 @@ static void rx_callback(struct libusb_transfer * const transfer){
   int64_t const now = gps_time_ns();
 
   sdr->xfers_in_progress--;
-  sdr->last_callback_time = now;
+  // NB: last_callback_time is intentionally NOT updated here. It must be updated only when a
+  // transfer actually delivers data (see below), otherwise a wedged FX3 that returns endless
+  // failed/empty transfers keeps the watchdog timer fresh and proc_rx888() can never trip.
 
   if(transfer->status == LIBUSB_TRANSFER_NO_DEVICE){
     usb_device_gone = 1;
@@ -615,6 +646,20 @@ static void rx_callback(struct libusb_transfer * const transfer){
 
   // successful USB transfer
   int const size = transfer->actual_length;
+  if(size <= 0) {
+    // Completion without data is also a wedge symptom — don't refresh the watchdog.
+    if(atomic_load(&sdr->state) == RUNNING) {
+      if(libusb_submit_transfer(transfer) == 0)
+        sdr->xfers_in_progress++;
+    }
+    return;
+  }
+  sdr->last_callback_time = now;            // <-- moved: only refresh on real data
+  if(sdr->recovery_tier != 0) {
+    fprintf(stderr,"RX888 data flow restored after Tier-%d recovery\n", sdr->recovery_tier);
+    sdr->recovery_tier = 0;
+    sdr->recovery_grace_until = 0;
+  }
   sdr->success_count++;
 
   // Feed directly into FFT input buffer, accumulate energy


### PR DESCRIPTION
This addresses a mid-stream wedge mode where the FX3 silently stops delivering samples while remaining responsive to USB control transfers. Before this patch, `radiod` sat in the wedge indefinitely; only a physical replug cleared it. Observed twice on a Raspberry Pi 5 / RX888mk2 station in a single day.

## 1. Wedge-detection fix in `rx_callback`

`rx_callback()` updated `sdr->last_callback_time` unconditionally, before the transfer status check. When the FX3 wedges and starts handing back failed/empty transfers, the callback still fires for each one, `last_callback_time` keeps refreshing, and the *"No rx888 data for 5 seconds"* watchdog in `proc_rx888()` can never trip. `frontend->samples` meanwhile stops incrementing, so `agc_rx888()` correctly sees a measured sample rate of 0 Hz and logs it every minute — but has no authority to abort.

Fix: only update `last_callback_time` on a successful, non-empty transfer. The existing `LIBUSB_TRANSFER_NO_DEVICE` → `usb_device_gone` → immediate-exit path is preserved.

## 2. In-driver tiered recovery via FX3 vendor commands

The SDDC FX3 firmware already exposes vendor commands that can recover the chip without external intervention (see `ExtIO_sddc/SDDC_FX3/USBhandler.c`):

| Code | Name | Action in firmware |
|---|---|---|
| `0xAA` | `STARTFX3` | Reset DMA channel, re-enable GPIF SW input |
| `0xAB` | `STOPFX3`  | Disable GPIF SW input, reset DMA channel, flush USB EP |
| `0xB1` | `RESETFX3` | `CyU3PDeviceReset(CyFalse)` — full chip soft reset + USB re-enumeration |

This patch wires them into `proc_rx888()`'s wedge handler as a two-tier escalation:

- **Tier-1a**: `STOPFX3` → 500 ms → `STARTFX3`. In-stream, no USB re-enumeration. Resets the DMA producer-side state — sufficient for stalls caused by transient back-pressure on the `CY_U3P_DMA_TYPE_AUTO_MANY_TO_ONE` channel. ~0.5 s, 30 s grace window for data to resume.
- **Tier-1b**: `RESETFX3` then `exit(EX_NOINPUT)`. Full chip reset; the USB re-enumeration through bootloader (`04b4:00f3`) + fxload makes the libusb handle invalid anyway, so we exit and let the supervisor (systemd / docker / shell loop) restart us. ~1 s of USB time.

`rx_callback()` resets the tier counter to 0 the moment real data flows again, so a one-off recovery doesn't permanently consume the budget.

## Validation

- Compiles clean with `-Wall -Wextra`.
- Both vendor commands validated by manual USB control transfer on a healthy RX888mk2:
  - `STOPFX3 + STARTFX3`: silent DMA reset, no USB-layer event, sub-second.
  - `RESETFX3`: full chip reset; observed `04b4:00f1` → `04b4:00f3` (Cypress bootloader) → fxload → `04b4:00f1` re-enumeration in ~1 s. Functionally equivalent to a physical replug.
- Patched build (against a Docker-packaged downstream fork that shares this `rx888.c`) running in production on a Pi 5 / RX888mk2 station for >18 h at time of submission. Baseline before the patch was ~2 organic wedges per day on the same hardware.

The escalation has not yet been observed firing on a real wedge in the patched binary, because the patched binary has not wedged in its first 18 h. So we know it doesn't regress normal operation; we don't yet know it cures the wedge case it was designed for. The mechanism is plausible from the FX3 data-path architecture (`StartStopApplication.c` configures a `CY_U3P_DMA_TYPE_AUTO_MANY_TO_ONE` channel with no flow control or error callback, and `Pib_error_cb` is commented out), and the worst case is no worse than today's behaviour (clean exit on watchdog).