### PR TITLE
Audit fixes: security, correctness, and build hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,39 @@ old
 Temporary Items
 work
 stash
+
+# build products
+*.o
+*.a
+*.so
+*.d
+src/config_paths.h
+
+# built binaries (src/Makefile DAEMONS + EXECS + old/obsolete targets)
+src/aprs
+src/aprsfeed
+src/control
+src/ctcss
+src/cwd
+src/fft-gen
+src/jt-decoded
+src/metadump
+src/monitor
+src/opusd
+src/opussend
+src/packetd
+src/pcmcat
+src/pcmrecord
+src/pcmsend
+src/pcmspawn
+src/powers
+src/radiod
+src/rdsd
+src/rx888_boot
+src/setfilt
+src/set_xcvr
+src/show-pkt
+src/show-sig
+src/stereod
+src/tune
+src/wd-record

--- a/rules/54-bladerf.rules
+++ b/rules/54-bladerf.rules
@@ -1,0 +1,15 @@
+# Nuand BladeRF USB permissions
+# Grants plugdev group access via uaccess so radiod (member of
+# plugdev) can open the device without root. Analogous to
+# 51-airspy.rules and 71-rx888.rules. For host-specific autostart
+# (SYSTEMD_WANTS to a radiod@<instance>.service), add a
+# 55-bladerf-ka9q.rules that matches on the serial number.
+
+# BladeRF (original)
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5246", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+
+# BladeRF 2.0 micro
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2cf0", ATTR{idProduct}=="5250", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+
+# Older Nuand (pre-Nuand vendor ID assignment)
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6066", MODE="0660", GROUP="plugdev", TAG+="uaccess"

--- a/rules/Makefile
+++ b/rules/Makefile
@@ -4,7 +4,7 @@
 udevdir	      ?= /etc/udev/rules.d
 
 UNAME_S := $(shell uname -s)
-RULES = 20-rtlsdr.rules 51-airspy.rules 51-hydrasdr.rules 52-airspyhf.rules 53-airspy-ka9q.rules 66-hackrf.rules 66-sdrplay.rules \
+RULES = 20-rtlsdr.rules 51-airspy.rules 51-hydrasdr.rules 52-airspyhf.rules 53-airspy-ka9q.rules 54-bladerf.rules 66-hackrf.rules 66-sdrplay.rules \
 	68-funcube-dongle-proplus.rules 68-funcube-dongle.rules 69-funcube-ka9q.rules 70-rx888-boot.rules 71-rx888.rules \
 	72-rx888-ka9q.rules 73-fobos-sdr.rules 74-fobos-sdr-ka9q.rules
 

--- a/service/radiod@.service.in
+++ b/service/radiod@.service.in
@@ -20,6 +20,23 @@ StateDirectoryMode=0775
 LogsDirectory=ka9q-radio
 LogsDirectoryMode=0775
 UMask=002
+# Sandboxing. Conservative set: no new privileges, private /tmp,
+# read-only /usr and /etc (StateDirectory and LogsDirectory are
+# bind-mounted writeable), no visibility of /home, restrict
+# personalities, kernel-tunables writes, module loading, cgroup
+# manipulation, namespaces, realtime scheduling, and setuid.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 ExecStart=@sbindir@/radiod -N %i /etc/radio/radiod@%i.conf
 # eventually it will be Restart=on-failure after udev-triggered
 # starting is implemented

--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ ARCHOPTS = -march=native
 endif
 
 # do NOT set -ffast-math or -ffinite-math-only; NANs are widely used as 'variable not set' sentinels
-COPTS = -std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -freciprocal-math -fno-trapping-math -Wextra -Wno-sign-conversion -Wno-int-conversion -MMD -MP
+COPTS = -std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -freciprocal-math -fno-trapping-math -Wextra -MMD -MP
 COPTS += -fPIC
 CFLAGS += $(DOPTS) $(ARCHOPTS) $(COPTS) $(INCLUDES)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -96,7 +96,11 @@ LIBSTATUS = status.o decode_status.o
 RADIOD_OBJECTS = main.o audio.o avahi.o modes.o fm.o wfm.o linear.o spectrum.o radio.o radio_status.o rtcp.o libdsp.a libstatus.a libradio.a
 
 ## source files for dependency generation (see DEPS=)
-CFILES = airspy.c airspyhf.c aprs.c aprsfeed.c attr.c audio.c avahi.c avahi_browse.c ax25.c bandplan.c config.c control.c cwd.c decimate.c decode_status.c dump.c ezusb.c fcd.c filter.c fm.c funcube.c hid-libusb.c iir.c jt-decoded.c linear.c main.c metadump.c misc.c modes.c monitor.c monitor-data.c monitor-display.c monitor-repeater.c morse.c multicast.c opusd.c opussend.c osc.c packetd.c pcmcat.c pcmrecord.c pcmsend.c pcmspawn.c ctcss.c powers.c radio.c radio_status.c rdsd.c rtcp.c rtlsdr.c rtp.c rx888.c setfilt.c show-pkt.c show-sig.c si5351.c sig_gen.c spectrum.c status.c stereod.c tune.c wd-record.c wfm.c
+# List every .c file in the tree so `-include $(DEPS)` picks up
+# header-change rebuild dependencies even for optional drivers
+# (bladerf, fobos, hackrf, hydrasdr, sdrplay, ...) whose targets
+# are gated by ENABLE_*.
+CFILES = airspy.c airspyhf.c aprs.c aprsfeed.c attr.c audio.c avahi.c avahi_browse.c ax25.c bandplan.c bladerf.c config.c control.c cwd.c decimate.c decode_status.c dump.c ezusb.c fcd.c fft-gen.c filter.c fm.c fobos.c funcube.c gauss.c hackrf.c hid-libusb.c hydrasdr.c iir.c jt-decoded.c linear.c main.c metadump.c misc.c modes.c monitor.c monitor-data.c monitor-display.c monitor-repeater.c morse.c multicast.c opusd.c opussend.c osc.c packetd.c pcmcat.c pcmrecord.c pcmsend.c pcmspawn.c ctcss.c powers.c radio.c radio_status.c rdsd.c rtcp.c rtlsdr.c rtp.c rx888.c rx888_boot.c sdrplay.c set_xcvr.c setfilt.c show-pkt.c show-sig.c si5351.c sig_gen.c spectrum.c status.c stereod.c sincospi.c sincospif.c tune.c wd-record.c wfm.c window.c
 HFILES = attr.h ax25.h bandplan.h conf.h config.h decimate.h ezusb.h fcd.h fcdhidcmd.h filter.h hidapi.h iir.h misc.h monitor.h morse.h multicast.h osc.h radio.h rx888.h si5351.h status.h config_paths.h
 
 ## hardware plug-in module enables
@@ -105,71 +109,59 @@ DYNAMIC_DRIVERS =
 
 # AIRSPY R2, etc
 ifeq ($(ENABLE_AIRSPY),1)
-   CFILES += airspy.c
    DYNAMIC_DRIVERS += airspy.so
 endif
 
 # AIRSPY HF+
 ifeq ($(ENABLE_AIRSPYHF),1)
-   CFILES += airspyhf.c
    DYNAMIC_DRIVERS += airspyhf.so
 endif
 
 # BLADERF
 ifeq ($(ENABLE_BLADERF),1)
-   CFILES += bladerf.c
    DYNAMIC_DRIVERS += bladerf.so
 endif
 
 # Rigexpert Fobos SDR
 ifeq ($(ENABLE_FOBOS),1)
-   CFILES += fobos.c
    DYNAMIC_DRIVERS += fobos.so
 endif
 
 # Old AMSAT-UK Funcube dongle (my first SDR!)
 ifeq ($(ENABLE_FUNCUBE),1)
-   CFILES += funcube.c
    DYNAMIC_DRIVERS += funcube.so
 endif
 
 # HACK RF
 ifeq ($(ENABLE_HACKRF),1)
-   CFILES += hackrf.c
    DYNAMIC_DRIVERS += hackrf.so
 endif
 
 # HydraSDR One
 ifeq ($(ENABLE_HYDRASDR),1)
-   CFILES += hydrasdr.c
    DYNAMIC_DRIVERS += hydrasdr.so
 endif
 
 # cheap RTLSDR dongles
 ifeq ($(ENABLE_RTLSDR),1)
-   CFILES += rtlsdr.c
    DYNAMIC_DRIVERS += rtlsdr.so
 endif
 
 # RX 888 MkII
 ifeq ($(ENABLE_RX888),1)
-   CFILES += rx888.c rx888_boot.c
    DYNAMIC_DRIVERS += rx888.so
    DAEMONS += rx888_boot
 endif
 
 ifeq ($(ENABLE_SDRPLAY),1)
-   CFILES += sdrplay.c
    DYNAMIC_DRIVERS += sdrplay.so
 endif
 
 ifeq ($(ENABLE_SIG_GEN),1)
-   CFILES += sig_gen.c
    DYNAMIC_DRIVERS += sig_gen.so
 endif
 
 ifeq ($(HAS_PIGPIO),1)
-   CFILES += set_xcvr.c
    EXECS += set_xcvr
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -183,7 +183,7 @@ install: all
 	install -m 0755 $(DAEMONS) $(DESTDIR)$(sbindir)
 	install -m 0755 $(EXECS) $(DESTDIR)$(bindir)
 ifeq ($(strip $(DEB_BUILD_ARCH))$(UNAME_S),Linux)
-	setcap cap_net_admin+ep $(bindir)/monitor
+	setcap cap_net_admin+ep $(DESTDIR)$(bindir)/monitor
 endif
 
 clean:

--- a/src/audio.c
+++ b/src/audio.c
@@ -89,7 +89,12 @@ int send_output(struct channel * restrict const chan, float const * restrict buf
 	  copylen = frames; // limit to what we have
 	assert(chan->output.queue != NULL);
 	sanity_check(chan->output.queue, chan->output.queue_length * chan->output.channels);
-	chan->output.queue = realloc(chan->output.queue, (chan->output.queue_length + copylen) * chan->output.channels * sizeof(float));
+	{
+	  // Use a temp so a realloc failure doesn't leak the old queue.
+	  float *tmp = realloc(chan->output.queue, (chan->output.queue_length + copylen) * chan->output.channels * sizeof(float));
+	  assert(tmp != NULL);
+	  chan->output.queue = tmp;
+	}
 	assert(chan->output.queue != NULL);
 	sanity_check(chan->output.queue, chan->output.queue_length * chan->output.channels);
 	memcpy(chan->output.queue + chan->output.channels * chan->output.queue_length,

--- a/src/bladerf.c
+++ b/src/bladerf.c
@@ -313,8 +313,8 @@ int bladerf_stop(struct frontend * const frontend){
       return 0;
     usleep(10000);
   }
-  pthread_join(&sdr->main_thread, NULL);
-  pthread_join(&sdr->monitor_thread, NULL);
+  pthread_join(sdr->main_thread, NULL);
+  pthread_join(sdr->monitor_thread, NULL);
   atomic_store(&sdr->state,STOPPED);
   fprintf(stderr,"bladerf stopped\n");
   return 0;

--- a/src/decode_status.c
+++ b/src/decode_status.c
@@ -20,10 +20,16 @@ int decode_radio_status(struct frontend *frontend,struct channel *channel,uint8_
     enum status_type type = *cp++; // increment to length field
     if(type == EOL)
       break; // end of list
+    if(cp >= &buffer[length])
+      break; // truncated: no length byte
     unsigned int optlen = *cp++;
     if(optlen & 0x80){
       // length is >= 128 bytes; fetch actual length from next N bytes, where N is low 7 bits of optlen
       int length_of_length = optlen & 0x7f;
+      // Reject implausible or overflowing lengths, and ensure the length
+      // bytes themselves fit in the remaining packet.
+      if(length_of_length > (int)sizeof(optlen) || cp + length_of_length > &buffer[length])
+	break;
       optlen = 0;
       while(length_of_length > 0){
 	optlen <<= 8;
@@ -31,8 +37,8 @@ int decode_radio_status(struct frontend *frontend,struct channel *channel,uint8_
 	length_of_length--;
       }
     }
-    if(cp >= &buffer[length])
-      break; // invalid length; we can't continue to scan
+    if(optlen > (size_t)(&buffer[length] - cp))
+      break; // value would run past end of packet
     switch(type){
     case EOL:
       break;
@@ -42,7 +48,8 @@ int decode_radio_status(struct frontend *frontend,struct channel *channel,uint8_
     case DESCRIPTION:
       {
 	char *str = decode_string(cp,optlen);
-	strlcpy(frontend->description,str,sizeof(frontend->description)); // should enforce null termination
+	if(str != NULL)
+	  strlcpy(frontend->description,str,sizeof(frontend->description)); // strlcpy null-terminates
 	FREE(str);
       }
       break;
@@ -303,7 +310,8 @@ int decode_radio_status(struct frontend *frontend,struct channel *channel,uint8_
     case PRESET:
       {
 	char *p = decode_string(cp,optlen);
-	strlcpy(channel->preset,p,sizeof(channel->preset)); // should enforce null termination
+	if(p != NULL)
+	  strlcpy(channel->preset,p,sizeof(channel->preset)); // strlcpy null-terminates
 	FREE(p);
       }
       break;
@@ -377,10 +385,13 @@ uint32_t get_ssrc(uint8_t const *buffer,int length){
     enum status_type const type = *cp++; // increment cp to length field
     if(type == EOL)
       break; // end of list, no length
+    if(cp >= &buffer[length])
+      break; // truncated: no length byte
     unsigned int optlen = *cp++;
     if(optlen & 0x80){
-      // length is >= 128 bytes; fetch actual length from next N bytes, where N is low 7 bits of optlen
       int length_of_length = optlen & 0x7f;
+      if(length_of_length > (int)sizeof(optlen) || cp + length_of_length > &buffer[length])
+	break;
       optlen = 0;
       while(length_of_length > 0){
 	optlen <<= 8;
@@ -388,8 +399,8 @@ uint32_t get_ssrc(uint8_t const *buffer,int length){
 	length_of_length--;
       }
     }
-    if(cp + optlen >= buffer + length)
-      break; // invalid length; we can't continue to scan
+    if(optlen > (size_t)(&buffer[length] - cp))
+      break; // value would run past end of packet
     switch(type){
     case EOL: // Shouldn't get here
       goto done;
@@ -413,10 +424,13 @@ uint32_t get_tag(uint8_t const *buffer,int length){
     enum status_type const type = *cp++; // increment cp to length field
     if(type == EOL)
       break; // end of list, no length
+    if(cp >= buffer + length)
+      break; // truncated: no length byte
     unsigned int optlen = *cp++;
     if(optlen & 0x80){
-      // length is >= 128 bytes; fetch actual length from next N bytes, where N is low 7 bits of optlen
       int length_of_length = optlen & 0x7f;
+      if(length_of_length > (int)sizeof(optlen) || cp + length_of_length > buffer + length)
+	break;
       optlen = 0;
       while(length_of_length > 0){
 	optlen <<= 8;
@@ -424,8 +438,8 @@ uint32_t get_tag(uint8_t const *buffer,int length){
 	length_of_length--;
       }
     }
-    if(cp + optlen >= buffer + length)
-      break; // invalid length; we can't continue to scan
+    if(optlen > (size_t)(buffer + length - cp))
+      break; // value would run past end of packet
     switch(type){
     case EOL: // Shouldn't get here
       goto done;

--- a/src/filter.c
+++ b/src/filter.c
@@ -73,9 +73,11 @@ static struct {
   struct fft_job *job_queue;
   pthread_t thread[NTHREADS_MAX];  // Worker threads
 } FFT;
+// Bin-wrap helper: returns x mod m in [0, m).
+// Robust for any int x (not just x in (-m, m]).
 static inline int modulo(int x,int const m){
-  x = x < 0 ? x + m : x;
-  return x > m ? x - m : x;
+  int const r = x % m;
+  return r < 0 ? r + m : r;
 }
 // in MAY be the same as out, meaning a in-place transform.
 fftwf_plan plan_complex(int N, float complex *in, float complex *out, int direction){

--- a/src/linear.c
+++ b/src/linear.c
@@ -218,6 +218,8 @@ int demod_linear(void *arg){
 	// Divide into 2 ms slices. Hopefully divides evenly (it does for the usual sampling rates and block times)
 	// Should handle fractions if that ever happens
 	int samples_per_slice = lrint(N * .002 / Blocktime);
+	if(samples_per_slice < 1)
+	  samples_per_slice = 1; // guard: very large Blocktime would give 0 and spin the loop
 	int n = 0;
 	while(n + samples_per_slice < N){ // ignore any fragment at end
 	  double energy = 0;

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -379,11 +379,12 @@ char *formataddr(char *result, int size, void const *sock){
 // Convert binary sockaddr structure to printable host:port string
 // cache result, as getnameinfo can be very slow when it doesn't get a reverse DNS hit
 
-// Needs locks to be made thread safe.
-// Unfortunately, getnameinfo() can be very slow (the whole reason we need a cache!)
-// so we let go of the lock while it executes. That might cause duplicate entries
-// if two callers look up the same unresolved name at the same time, but that doesn't
-// seem likely to cause a problem?
+// Bounded LRU: MRU at head, evict from tail once size hits INVERSE_CACHE_MAX.
+// getnameinfo() runs with the lock dropped since it can be very slow; on
+// re-acquire we re-scan to avoid inserting a duplicate if another thread
+// resolved the same address in the meantime.
+
+#define INVERSE_CACHE_MAX 4096
 
 struct inverse_cache {
   struct inverse_cache *next;
@@ -392,9 +393,44 @@ struct inverse_cache {
   char hostport [2*NI_MAXHOST+NI_MAXSERV+5];
 };
 
-static struct inverse_cache *Inverse_cache_table; // Head of cache linked list
+static struct inverse_cache *Inverse_cache_head;
+static struct inverse_cache *Inverse_cache_tail;
+static size_t Inverse_cache_count;
 
 static pthread_mutex_t Formatsock_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Find matching entry (lock must be held). NULL if not present.
+static struct inverse_cache *inverse_cache_find(struct sockaddr const *sa){
+  for(struct inverse_cache *ic = Inverse_cache_head; ic != NULL; ic = ic->next){
+    if(address_match(&ic->sock, sa) && getportnumber(&ic->sock) == getportnumber(sa))
+      return ic;
+  }
+  return NULL;
+}
+
+// Unlink an entry from the LRU list (lock must be held).
+static void inverse_cache_unlink(struct inverse_cache *ic){
+  if(ic->prev != NULL)
+    ic->prev->next = ic->next;
+  else
+    Inverse_cache_head = ic->next;
+  if(ic->next != NULL)
+    ic->next->prev = ic->prev;
+  else
+    Inverse_cache_tail = ic->prev;
+  ic->prev = ic->next = NULL;
+}
+
+// Push at head (lock must be held).
+static void inverse_cache_push_head(struct inverse_cache *ic){
+  ic->prev = NULL;
+  ic->next = Inverse_cache_head;
+  if(Inverse_cache_head != NULL)
+    Inverse_cache_head->prev = ic;
+  else
+    Inverse_cache_tail = ic;
+  Inverse_cache_head = ic;
+}
 
 // We actually take a sockaddr *, but can also accept a sockaddr_in *, sockaddr_in6 * and sockaddr_storage *
 // so to make it easier for callers we just take a void * and avoid pointer casts that impair readability
@@ -417,24 +453,14 @@ char const *formatsock(void const *s,bool full){
     return NULL;
   }
   pthread_mutex_lock(&Formatsock_mutex);
-  for(struct inverse_cache *ic = Inverse_cache_table; ic != NULL; ic = ic->next){
-    if(address_match(&ic->sock, sa) && getportnumber(&ic->sock) == getportnumber(sa)){
-      if(ic->prev == NULL){
-	pthread_mutex_unlock(&Formatsock_mutex);
-	return ic->hostport; // Already at top of list
-      }
-      // move to top of list so it'll be faster to find if we look for it again soon
-      ic->prev->next = ic->next;
-      if(ic->next)
-	ic->next->prev = ic->prev;
-
-      ic->next = Inverse_cache_table;
-      ic->next->prev = ic;
-      ic->prev = NULL;
-      Inverse_cache_table = ic;
-      pthread_mutex_unlock(&Formatsock_mutex);
-      return ic->hostport;
+  struct inverse_cache *hit = inverse_cache_find(sa);
+  if(hit != NULL){
+    if(hit != Inverse_cache_head){
+      inverse_cache_unlink(hit);
+      inverse_cache_push_head(hit);
     }
+    pthread_mutex_unlock(&Formatsock_mutex);
+    return hit->hostport;
   }
   pthread_mutex_unlock(&Formatsock_mutex); // Let go of the lock, this will take a while
   // Not in list yet
@@ -461,12 +487,27 @@ char const *formatsock(void const *s,bool full){
   assert(slen < sizeof(ic->sock));
   memcpy(&ic->sock, sa, slen);
 
-  // Put at head of table
   pthread_mutex_lock(&Formatsock_mutex);
-  ic->next = Inverse_cache_table;
-  if(ic->next)
-    ic->next->prev = ic;
-  Inverse_cache_table = ic;
+  // Another thread may have inserted the same entry while we dropped the lock.
+  hit = inverse_cache_find(sa);
+  if(hit != NULL){
+    if(hit != Inverse_cache_head){
+      inverse_cache_unlink(hit);
+      inverse_cache_push_head(hit);
+    }
+    pthread_mutex_unlock(&Formatsock_mutex);
+    free(ic);
+    return hit->hostport;
+  }
+  // Enforce size bound by evicting the least-recently-used entry.
+  if(Inverse_cache_count >= INVERSE_CACHE_MAX && Inverse_cache_tail != NULL){
+    struct inverse_cache *evict = Inverse_cache_tail;
+    inverse_cache_unlink(evict);
+    Inverse_cache_count--;
+    free(evict);
+  }
+  inverse_cache_push_head(ic);
+  Inverse_cache_count++;
   pthread_mutex_unlock(&Formatsock_mutex);
   return ic->hostport;
 }

--- a/src/pcmrecord.c
+++ b/src/pcmrecord.c
@@ -413,7 +413,6 @@ int main(int argc,char *argv[]){
   // Graceful signal catch
   signal(SIGPIPE,closedown); // Should catch the --exec or --stdout receiving process terminating
   signal(SIGINT,closedown);
-  signal(SIGKILL,closedown);
   signal(SIGQUIT,closedown);
   signal(SIGTERM,closedown);
 

--- a/src/pcmrecord.c
+++ b/src/pcmrecord.c
@@ -1146,7 +1146,9 @@ static int session_file_init(struct session *sp,struct sockaddr const *sender,in
 	      sp->chan.preset);
     return 0;
   } else if(Command != NULL){
-    // Substitute parameters as specified
+    // Substitute parameters as specified. Substituted values are wrapped in
+    // single quotes so that shell metacharacters (e.g., in a rogue radiod
+    // description via $d) are treated as literal text, not shell syntax.
     sp->can_seek = false; // Can't seek on a pipe
     sp->exit_after_close = false; // Runs forever, closing individual pipes on timeout
     sp->filename[0] = '\0';
@@ -1157,39 +1159,57 @@ static int session_file_init(struct session *sp,struct sockaddr const *sender,in
     while((a = strsep(&cp,"$")) != NULL){
       strlcat(sp->filename,a,sizeof(sp->filename));
       if(cp != NULL && strlen(cp) > 0){
-	char temp[256];
+	char raw[256];
+	bool quote = true;   // wrap substituted value in single quotes
+	raw[0] = '\0';
 	switch(*cp++){
 	case '$':
-	  snprintf(temp,sizeof(temp),"$");
+	  strlcpy(raw,"$",sizeof(raw));
+	  quote = false; // literal '$'
 	  break;
 	case 'd':
-	  snprintf(temp,sizeof(temp),"%s",sp->frontend.description);
+	  snprintf(raw,sizeof(raw),"%s",sp->frontend.description);
 	  break;
 	case 'h':
-	  snprintf(temp,sizeof(temp),"%.1lf",sp->chan.tune.freq);
+	  snprintf(raw,sizeof(raw),"%.1lf",sp->chan.tune.freq);
 	  break;
 	case 'k':
-	  snprintf(temp,sizeof(temp),"%.4lf",sp->chan.tune.freq/1000.);
+	  snprintf(raw,sizeof(raw),"%.4lf",sp->chan.tune.freq/1000.);
 	  break;
 	case 'm':
-	  snprintf(temp,sizeof(temp),"%.7lf",sp->chan.tune.freq/1000000.);
+	  snprintf(raw,sizeof(raw),"%.7lf",sp->chan.tune.freq/1000000.);
 	  break;
 	case 'c':
-	  snprintf(temp,sizeof(temp),"%d",sp->channels);
+	  snprintf(raw,sizeof(raw),"%d",sp->channels);
 	  break;
 	case 'r':
-	  snprintf(temp,sizeof(temp),"%d",sp->chan.output.samprate); // rx sample rate even for Opus
+	  snprintf(raw,sizeof(raw),"%d",sp->chan.output.samprate); // rx sample rate even for Opus
 	  break;
 	case 's':
-	  snprintf(temp,sizeof(temp),"%u",sp->ssrc);
+	  snprintf(raw,sizeof(raw),"%u",sp->ssrc);
 	  break;
 	case 'f':
-	  snprintf(temp,sizeof temp, "%s", encoding_string(sp->encoding));
+	  snprintf(raw,sizeof raw, "%s", encoding_string(sp->encoding));
 	  break;
 	default:
 	  break;
 	}
-	size_t r = strlcat(sp->filename,temp,sizeof(sp->filename));
+	size_t r;
+	if(!quote){
+	  r = strlcat(sp->filename,raw,sizeof(sp->filename));
+	} else {
+	  // Shell-quote: 'raw' with any embedded ' replaced by '\''
+	  r = strlcat(sp->filename,"'",sizeof(sp->filename));
+	  for(char const *q = raw; *q != '\0' && r < sizeof(sp->filename); q++){
+	    if(*q == '\''){
+	      r = strlcat(sp->filename,"'\\''",sizeof(sp->filename));
+	    } else {
+	      char one[2] = { *q, '\0' };
+	      r = strlcat(sp->filename,one,sizeof(sp->filename));
+	    }
+	  }
+	  r = strlcat(sp->filename,"'",sizeof(sp->filename));
+	}
 	if(r >= sizeof sp->filename){
 	  fprintf(stderr,"filename overflow\n");
 	  return -1;

--- a/src/pcmspawn.c
+++ b/src/pcmspawn.c
@@ -162,7 +162,6 @@ int main(int argc,char * const argv[]){
   // Graceful signal catch
   signal(SIGPIPE,closedown);
   signal(SIGINT,closedown);
-  signal(SIGKILL,closedown);
   signal(SIGQUIT,closedown);
   signal(SIGTERM,closedown);
   signal(SIGPIPE,SIG_IGN);

--- a/src/radio.c
+++ b/src/radio.c
@@ -601,25 +601,35 @@ static int setup_hardware(char const *sname){
     }
     snprintf(symname,sizeof(symname),"%s_shutdown",device);
     Frontend.shutdown = dlsym(Dl_handle,symname);
-    if(Verbose && (error = dlerror()) != NULL)
-      fprintf(stderr,"no %s_shutdown symbol: %s\n",device,error);
+    if((error = dlerror()) != NULL){
+      Frontend.shutdown = NULL;
+      if(Verbose)
+	fprintf(stderr,"no %s_shutdown symbol: %s\n",device,error);
+    }
 
     snprintf(symname,sizeof(symname),"%s_tune",device);
     Frontend.tune = dlsym(Dl_handle,symname);
     if((error = dlerror()) != NULL){
       // Not fatal, but no tuning possible
+      Frontend.tune = NULL;
       fprintf(stderr,"warning: symbol %s not found in %s for %s: %s\n",symname,dlname,device,error);
     }
     // No error checking on these, they're optional
     snprintf(symname,sizeof(symname),"%s_gain",device);
     Frontend.gain = dlsym(Dl_handle,symname);
-    if(Verbose && (error = dlerror()) != NULL) // Not serious errors
-      fprintf(stderr,"no %s_gain symbol: %s\n",device,error);
+    if((error = dlerror()) != NULL){
+      Frontend.gain = NULL;
+      if(Verbose) // Not serious errors
+	fprintf(stderr,"no %s_gain symbol: %s\n",device,error);
+    }
 
     snprintf(symname,sizeof(symname),"%s_atten",device);
     Frontend.atten = dlsym(Dl_handle,symname);
-    if(Verbose && (error = dlerror()) != NULL)
-      fprintf(stderr,"no %s_atten symbol: %s\n",device,error);
+    if((error = dlerror()) != NULL){
+      Frontend.atten = NULL;
+      if(Verbose)
+	fprintf(stderr,"no %s_atten symbol: %s\n",device,error);
+    }
   }
   int r = (*Frontend.setup)(&Frontend,Configtable,sname);
   if(r != 0){

--- a/src/radio.c
+++ b/src/radio.c
@@ -780,7 +780,7 @@ static void *process_section(void *p){
     if(pt == -1){
       fprintf(stderr,"channel template: can't allocate payload type for samprate %'d, channels %d, encoding %d\n",
 	      chan_template.output.samprate,chan_template.output.channels,chan_template.output.encoding); // make sure it's initialized
-	  return -1;
+      return NULL; // process_section is a pthread callback returning void *; join sites discard the result
     }
     chan_template.output.rtp.type = pt;
   }

--- a/src/radio_status.c
+++ b/src/radio_status.c
@@ -168,7 +168,8 @@ bool decode_radio_commands(struct channel *chan,uint8_t const *buffer,int length
       {
 	struct channel old = *chan; // Copy old to detect changes
 	char *p = decode_string(cp,optlen);
-	strlcpy(chan->preset,p,sizeof(chan->preset));
+	if(p != NULL)
+	  strlcpy(chan->preset,p,sizeof(chan->preset));
 	FREE(p); // decode_string now allocs memory
 	if(Verbose > 1)
 	  fprintf(stderr,"%s loadpreset(%s)\n",chan->name,chan->preset);

--- a/src/rx888.c
+++ b/src/rx888.c
@@ -931,9 +931,8 @@ static int rx888_usb_init(struct sdrstate *const sdr,const char * const firmware
 
 end:;
   free_transfer_buffers(sdr->databuffers,sdr->transfers,sdr->queuedepth);
-
-  FREE(sdr->transfers);
-  FREE(sdr->databuffers);
+  sdr->databuffers = NULL;
+  sdr->transfers = NULL;
 
   if(sdr->dev_handle != NULL)
     libusb_release_interface(sdr->dev_handle,0);

--- a/src/rx888.c
+++ b/src/rx888.c
@@ -56,13 +56,6 @@ static long long const DEFAULT_REFERENCE = 27e6;
 // Max allowable error on reference; 1e-4 = 100 ppm. Mainly to catch entry scaling errors
 static double const MAX_CALIBRATE = 1e-4;
 
-#if 0
-// Min and Max frequency for VHF/UHF tuner
-static long long const MIN_FREQUENCY = 50e6;   //  50 MHz ?
-static long long const MAX_FREQUENCY = 2000e6; // 2000 MHz
-static int const R828D_FREQ = 16000000;     // R820T reference frequency
-static int const R828D_IF_CARRIER = 4570000;
-#endif
 int Ezusb_verbose = 0; // Used by ezusb.c
 // Global variables set by config file options in main.c
 extern int Verbose;
@@ -142,10 +135,6 @@ static double val2gain(int g);
 static int gain2val(double gain);
 static void *proc_rx888(void *arg);
 static void *agc_rx888(void *arg);
-#if 0
-static double rx888_set_tuner_frequency(struct sdrstate *sdr,double frequency);
-static double actual_freq(double frequency);
-#endif
 // Read one Si5351 register over I2C (reg# is silicon-defined → version-proof).
 static inline int si5351_read(struct sdrstate *sdr, uint8_t reg, uint8_t *val){
   return control_recv(sdr->dev_handle, I2CRFX3, SI5351_ADDR, reg, val, 1);
@@ -394,32 +383,9 @@ int rx888_setup(struct frontend * const frontend,dictionary const * const dictio
 	  sdr->reqsize * sdr->pktsize,
 	  xfer_time);
 
-#if 0
-  // VHF-UHF tuning
-  {
-    char const *p = config_getstring(dictionary,section,"frequency",NULL);
-    if(p != NULL){
-      if(sdr->undersample > 1){
-	fprintf(stderr,"frequency = ignored in undersample mode\n");
-      } else {
-	double frequency = parse_frequency(p,false);
-	if(frequency < MIN_FREQUENCY || frequency > MAX_FREQUENCY){
-	  fprintf(stderr,"Invalid VHF/UHF frequency %'lf, ignoring\n",frequency);
-	} else {
-	  // VHF/UHF mode
-	  double actual_frequency = rx888_set_tuner_frequency(sdr,frequency);
-	  fprintf(stderr,"Actual VHF/UHF tuner frequency %'lf\n",actual_frequency);
-	  frontend->frequency = actual_frequency;
-	  rx888_set_att(sdr,att,true);
-	  rx888_set_gain(sdr,gain,true);
-	  frontend->lock = true;
-	}
-      }
-    }
-  }
-#else
+  // VHF/UHF tuner support was removed pending a firmware rewrite; the
+  // driver operates in HF-only mode.
   frontend->frequency = 0;
-#endif
   if(frontend->frequency == 0)
     rx888_set_hf_mode(sdr);
 
@@ -1004,37 +970,6 @@ static void rx888_set_hf_mode(struct sdrstate *sdr){
   command_send(sdr->dev_handle,GPIOFX3,sdr->gpios);
 }
 
-#if 0
-// Pretty sure this is broken
-static double rx888_set_tuner_frequency(struct sdrstate *sdr,double frequency){
-  assert(sdr != NULL);
-  struct frontend *frontend = sdr->frontend;
-  if(frequency == frontend->frequency)
-    return frequency;
-
-  if(frequency != 0.0){
-    // disable HF by set max ATT
-    rx888_set_att(sdr,31.5,false);  // max att 31.5 dB
-    // switch to VHF Antenna
-    sdr->gpios |= VHF_EN;
-    command_send(sdr->dev_handle,GPIOFX3,sdr->gpios);
-
-    // high gain, 0db
-    uint8_t gain = 0x80 | 3;
-    argument_send(sdr->dev_handle,AD8340_VGA,gain);
-
-    // Enable Tuner reference clock
-    uint32_t ref = R828D_FREQ;
-    command_send(sdr->dev_handle,TUNERINIT,ref); // Initialize Tuner
-    command_send(sdr->dev_handle,TUNERTUNE,(uint64_t)frequency);
-  } else {
-    rx888_set_hf_mode(sdr);
-  }
-  frontend->frequency = frequency;
-  return frequency;
-}
-#endif
-
 static int rx888_start_rx(struct sdrstate *sdr,libusb_transfer_cb_fn callback){
   assert(sdr != NULL);
   assert(callback != NULL);
@@ -1149,23 +1084,10 @@ static int gain2val(double gain){
   return g;
 }
 double rx888_tune(struct frontend *frontend,double freq){
-#if 1
   // Placeholder until VHF/UHF code is written
   (void)frontend;
   (void)freq;
-  return 0; // temp
-#else
-  struct sdrstate * const sdr = (struct sdrstate *)frontend->context;
-  if(frontend->lock || sdr->undersample != 1)
-    return frontend->frequency;
-  if(freq == 0.0){
-    frontend->frequency = 0;
-    rx888_set_hf_mode(sdr);
-    return 0;
-  } else {
-    return rx888_set_tuner_frequency(sdr,freq);
-  }
-#endif
+  return 0;
 }
 
 double rx888_set_samprate(struct sdrstate *sdr, long long const reference, long long const samprate){

--- a/src/status.c
+++ b/src/status.c
@@ -205,8 +205,9 @@ size_t encode_vector(uint8_t **bp,enum status_type type,float const *array,size_
 // OTOH, the caller doesn't have to figure out a buffer size anymore
 char *decode_string(uint8_t const *cp,int optlen){
   char *result = malloc(optlen+1);
-  if(result != NULL)
-    memcpy(result,cp,optlen);
+  if(result == NULL)
+    return NULL;
+  memcpy(result,cp,optlen);
   result[optlen] = '\0'; // force null termination
   return result;
 }

--- a/src/wd-record.c
+++ b/src/wd-record.c
@@ -594,7 +594,6 @@ int main(int argc,char *argv[]){
   // Graceful signal catch
   signal(SIGPIPE,closedown); // Should catch the --exec or --stdout receiving process terminating
   signal(SIGINT,closedown);
-  signal(SIGKILL,closedown);
   signal(SIGQUIT,closedown);
   signal(SIGTERM,closedown);
 


### PR DESCRIPTION
Nine self-contained commits from an audit pass on the current tree.
Each commit builds cleanly (0 warnings) and can be reviewed or dropped
independently. Grouped roughly by risk from lowest to highest:

## Hygiene

- `gitignore: add build products and installed binaries` — quiet `git status` after a `make -j`.
- `remove signal(SIGKILL, closedown) no-ops` — SIGKILL is uncatchable per POSIX; the three signal() calls in pcmrecord/pcmspawn/wd-record were no-ops that suggested cleanup that never runs.
- `rx888: remove dead #if 0 VHF/UHF tuner code` — `rx888_set_tuner_frequency` was marked "Pretty sure this is broken" and every reference was already inside `#if 0`. −78 net lines.

## Correctness

- `fix multiple correctness/safety bugs from audit`
  - `src/Makefile:186` — `setcap` gets `$(DESTDIR)$(bindir)` so Debian package builds stage the capability instead of writing to the build machine's live binary.
  - `src/status.c:decode_string` — return NULL on malloc failure instead of NULL-dereferencing. The three strlcpy callers in decode_status.c and radio_status.c now guard.
  - `src/decode_status.c` TLV parser — three copies of the type/length/value loop hardened: bounds-check the length byte read, reject a length-of-length exceeding sizeof(unsigned) or overrunning the packet, and use subtraction form for value bounds to avoid pointer-arithmetic wraparound.
  - `src/filter.c:modulo` — the helper `x > m ? x - m : x` returns `m` (out-of-bounds by one) when `x == m`. Replaced with `((x % m) + m) % m` which is correct for any int.
  - `src/rx888.c` USB init error path — removed a double-free: `free_transfer_buffers()` already frees the sdr->transfers and sdr->databuffers arrays; the caller was then FREE()ing them again. Matched the working pattern used in rx888_close.
- `harden two edge cases in AGC and audio queue`
  - `src/linear.c` — guard `samples_per_slice` against rounding to 0 (would spin the peak-finder loop) with an unusually large Blocktime.
  - `src/audio.c` — use a temporary around the queue realloc so an OOM failure doesn't leak the old queue.
- `enable -Wint-conversion and fix the three real bugs it catches`
  - `bladerf.c` — `pthread_join(&sdr->main_thread, ...)` was passing `pthread_t *` where `pthread_t` was expected (on glibc, `pthread_t` is an unsigned long, so this was passing an address as a thread ID). Two sites fixed to pass the value.
  - `radio.c` — `process_section` returns `void *` but one error path had `return -1;`. Inert (return value is discarded at the join sites) but a real type violation. Changed to `return NULL;`.

## Security

- `harden pcmrecord --exec substitution and bound multicast rDNS cache`
  - `pcmrecord.c:1167,1202` — the `--exec` `$d` macro substituted `sp->frontend.description` (a network-controlled string received over the multicast status channel) directly into the command handed to `popen()`. A rogue radiod on the LAN could set the description to shell metacharacters and land arbitrary code execution on any host running `pcmrecord --exec ... $d ...`. Every substituted value is now single-quoted with the standard `'\''` escaping.
  - `multicast.c:formatsock` — the reverse-DNS cache was a linked list with head insertion and no eviction; a long-running radiod exposed to many unique source addresses leaked memory forever. Also, two threads racing on the same unresolved address could each allocate and insert their own entry, duplicating it in the list. Converted to a bounded LRU (4096 entries) with a tail pointer for O(1) eviction, and a re-scan after re-acquiring the lock to close the duplicate-insert race.

## Build, packaging, plugin hygiene

- `build: dedupe driver sources; harden radiod@ service; add bladerf udev`
  - `src/Makefile` — base CFILES now lists every .c file including optional drivers (bladerf, fobos, hackrf, hydrasdr, sdrplay, rx888_boot, gauss, fft-gen, ...) so `-include $(DEPS)` picks up header-change rebuild dependencies uniformly. Removed the duplicate `CFILES += foo.c` from each ENABLE_* block.
  - `service/radiod@.service.in` — conservative sandboxing: `NoNewPrivileges`, `PrivateTmp`, `ProtectSystem=strict`, `ProtectHome`, `ProtectKernelTunables`, `ProtectKernelModules`, `ProtectControlGroups`, `LockPersonality`, `RestrictRealtime`, `RestrictSUIDSGID`, `RestrictNamespaces`, `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK`. Skipped `MemoryDenyWriteExecute` (FFTW SIMD dispatch) and `SystemCallFilter` (subtle breakage risk).
  - `rules/54-bladerf.rules` — plugdev/uaccess for Nuand BladeRF USB (original, 2.0 micro, and older pre-Nuand vendor ID). Analogous to the airspy and rx888 rules.
- `radio.c: explicitly NULL optional plugin fn pointers on dlsym miss` — defense-in-depth: on dlerror() for `_shutdown`, `_tune`, `_gain`, `_atten`, explicitly NULL the corresponding pointer. In practice dlsym returns NULL on function-symbol miss so this is belt-and-suspenders, but the code now makes it obvious that callers must NULL-check.

## Verification

- `make clean && make -j` completes with zero warnings on Ubuntu 24.04 with the full ENABLE_* set.
- Each commit tested to build individually.
- Three DSP claims from the audit were investigated and dismissed as false positives (osc.c renorm divide-by-zero — guarded by `is_phasor_init` requiring |x| ≥ √0.9; rx888 abs() on int16 — auto-promotes to int, INT16_MIN fits in int32; rx888 dc_offset — actually a proper leaky integrator α·N ≈ 0.1). No code change for those.
- Have not yet done a live-signal test against the RX888 rig here; happy to run one and report back if useful.

Please push back on any of these you'd rather leave alone; they're independent commits and easy to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)