### PR TITLE
Portable service discovery: add a `dns_sd.h` backend for mDNS

### DIFF
--- a/docs/PORTABLE-MDNS.md
+++ b/docs/PORTABLE-MDNS.md
@@ -111,7 +111,9 @@ DNSServiceBrowse ─► DNSServiceResolve ─► DNSServiceGetAddrInfo ─► ro
 It services the connection socket with `select()` under a bounded time budget
 (exiting early once results stop arriving), collects completed rows into the
 caller's `struct service_tab`, and applies the same sort + de-dupe-by-name
-policy as the `avahi` backend. Each row's strings are packed into a single
+policy as the `avahi` backend, with one addition: where duplicates of an
+instance differ by interface, a non-loopback one is kept (see section 5). Each
+row's strings are packed into a single
 `->buffer` allocation, so `avahi_free_service_table()` frees a row with one
 `free()` regardless of backend.
 
@@ -157,6 +159,16 @@ No binary links both, so the substitution is clean.
   publish mode (writing `/etc/avahi/hosts` and `/etc/avahi/services`) is specific
   to Avahi on Linux; the `dns_sd` backend always registers services live. The
   global remains defined so consumers link unchanged.
+
+- **Browse results prefer a non-loopback interface.** mDNSResponder reports a
+  locally published service on every interface it is visible on, so browsing for
+  a `radiod` running on the same host yields the same instance more than once —
+  typically once on `lo0` and once on the real interface. `control` passes the
+  surviving row's `->interface` straight to `listen_mcast()`/`join_group()`, so a
+  loopback row there would silently isolate it from the network. The de-dupe
+  therefore keeps a non-loopback row when the duplicates differ. This is rarely
+  visible on the `avahi` backend, where `avahi-daemon` does not normally browse
+  loopback.
 
 - **Name resolution is backend-independent.** Role 1 uses `getaddrinfo()`, so
   the `.local` name behavior documented in `docs/NETWORK-NOTES.md` is the same

--- a/docs/PORTABLE-MDNS.md
+++ b/docs/PORTABLE-MDNS.md
@@ -1,0 +1,198 @@
+# Portable service discovery (mDNS / DNS-SD)
+
+ka9q-radio uses multicast DNS (mDNS) / DNS-SD to advertise and discover its
+services on a local network, so the pieces find each other without
+hand-configured addresses. This document describes how service discovery works
+and how it is made portable across Linux, macOS, and FreeBSD.
+
+---
+
+## 1. What service discovery is used for
+
+ka9q-radio is multicast-native: all signal I/O rides on IP multicast. mDNS /
+DNS-SD is used in three distinct ways:
+
+1. **Name resolution** — `resolve_mcast()` in `multicast.c` appends `.local` to
+   unqualified names and calls plain `getaddrinfo()`. Every tool (`monitor`,
+   `pcmrecord`, `radiod` itself) turns a name like `nws.local` into a multicast
+   address this way. This uses only standard POSIX; it needs no ka9q-specific
+   code, only a host resolver that is mDNS-aware (native on macOS, `nss-mdns`
+   on Linux, `nss_mdns` on FreeBSD).
+
+2. **Advertising / publish** — `radiod` and the auxiliary daemons publish their
+   control channels (`_ka9q-ctl._udp`) and stream endpoints (`_rtp._udp`,
+   `_opus._udp`, `_ax25._udp`), including the name→multicast-address mapping
+   that other nodes' `getaddrinfo()` lookups resolve.
+
+3. **Enumeration / browse** — `control` browses `_ka9q-ctl._udp` to present a
+   list of running `radiod` instances to connect to.
+
+Only roles 2 and 3 use a platform-specific discovery **API**; role 1 is already
+portable through `getaddrinfo()`.
+
+> A separate, optional SAP/SDP announcer (`sap_send()` in `radio.c`, sent to
+> `sap.mcast.net`) advertises streams to *foreign* SDP consumers such as VLC.
+> It is send-only and independent of ka9q's own service discovery.
+
+---
+
+## 2. Two backends behind one interface
+
+Publish and browse (roles 2 and 3) are provided by one of two interchangeable
+backends, selected at build time:
+
+- **`avahi` backend** (`avahi.c` + `avahi_browse.c`) — used on Linux. It does
+  not link libavahi; it `fork`/`exec`s the `avahi-publish-service`,
+  `avahi-publish-address`, and `avahi-browse` command-line tools and parses
+  their text output.
+- **`dns_sd` backend** (`mdns.c`) — used on macOS and FreeBSD. It calls the
+  `dns_sd.h` (Bonjour / mDNSResponder) API directly.
+
+The two backends speak the same mDNS wire protocol, so nodes running different
+backends interoperate freely on the same network. The `dns_sd` backend exists
+because the `avahi-*` command-line tools it would otherwise depend on do not
+exist on macOS or FreeBSD, whereas `dns_sd.h` is available on all three
+platforms.
+
+Both backends implement the same small, stable interface, declared in
+`avahi.h`:
+
+```c
+extern bool Static_avahi;
+int  avahi_start(char const *service_name, char const *service_type, int service_port,
+                 char const *dns_name, int base_address, char const *description);
+int  avahi_browse(struct service_tab *table, int tabsize, char const *service_name);
+void avahi_free_service_table(struct service_tab *table, int tabsize);
+```
+
+`avahi.h` is provider-neutral: it declares only this interface and pulls in no
+libavahi or dns_sd headers, so the consumers (`radio.c`, `control.c`,
+`monitor.c`, `opusd.c`, `packetd.c`, `rdsd.c`, `stereod.c`) are identical
+regardless of which backend is compiled.
+
+```
+             ┌─────────────────────────────┐
+   consumers │  avahi.h  (interface only)  │
+   ───────►  └──────────────┬──────────────┘
+                            │  build-time selection
+              ┌─────────────┴──────────────┐
+              ▼                             ▼
+   avahi.c + avahi_browse.c            mdns.c
+   (Linux: exec avahi-* tools)   (macOS/FreeBSD: dns_sd.h)
+```
+
+---
+
+## 3. The `dns_sd` backend (`mdns.c`)
+
+`mdns.c` implements all three interface functions against the Bonjour API.
+
+### Publish — `avahi_start()`
+
+- `DNSServiceRegister()` registers the service (name, type, port, SRV target
+  host) with TXT records `pid=`, `description=`, and `source=<hostname>`.
+- When a multicast address is supplied, `DNSServiceRegisterRecord()` publishes
+  the `dns_name → address` A record, so remote `getaddrinfo(".local")` lookups
+  resolve.
+- All registrations share one `DNSServiceCreateConnection()` reference, kept
+  alive for the life of the process by a background thread that pumps
+  `DNSServiceProcessResult()`.
+
+### Browse — `avahi_browse()`
+
+The Bonjour browse/resolve calls are asynchronous, but `avahi_browse()` is a
+synchronous call that returns a filled table. `mdns.c` bridges the two by
+driving a pipeline on one shared connection:
+
+```
+DNSServiceBrowse ─► DNSServiceResolve ─► DNSServiceGetAddrInfo ─► row
+```
+
+It services the connection socket with `select()` under a bounded time budget
+(exiting early once results stop arriving), collects completed rows into the
+caller's `struct service_tab`, and applies the same sort + de-dupe-by-name
+policy as the `avahi` backend. Each row's strings are packed into a single
+`->buffer` allocation, so `avahi_free_service_table()` frees a row with one
+`free()` regardless of backend.
+
+---
+
+## 4. Build-time backend selection
+
+The Makefile chooses the backend automatically and lets you override it:
+
+```make
+MDNS_BACKEND ?= auto        # auto | avahi | dns_sd
+# auto: Linux → avahi, everything else → dns_sd
+```
+
+The backend objects are referenced indirectly:
+
+- `$(AVAHI_PUBLISH_OBJ)` — links into `radiod`, `opusd`, `packetd`, `rdsd`,
+  `stereod`
+- `$(AVAHI_BROWSE_OBJ)` — links into `control`
+
+In the `dns_sd` backend both resolve to `mdns.o` (which provides publish and
+browse); in the `avahi` backend they resolve to `avahi.o` and `avahi_browse.o`.
+No binary links both, so the substitution is clean.
+
+| Platform | `auto` backend | Objects | Link flag |
+|----------|----------------|---------|-----------|
+| Linux | `avahi` | `avahi.o`, `avahi_browse.o` | (avahi-* tools at runtime) |
+| macOS | `dns_sd` | `mdns.o` | none (`dns_sd` is in `libSystem`) |
+| FreeBSD | `dns_sd` | `mdns.o` | `-ldns_sd` (mDNSResponder port) |
+| Linux (forced) | `MDNS_BACKEND=dns_sd` | `mdns.o` | `-ldns_sd` (avahi-compat) |
+
+---
+
+## 5. Behavioral notes
+
+- **The `dns_sd` backend requires a full mDNSResponder implementation** — native
+  on macOS, the mDNSResponder port on FreeBSD. Linux uses the `avahi` backend by
+  default because Avahi's `libdns_sd` compatibility shim is less reliable for
+  `DNSServiceGetAddrInfo` and shared connections. A forced `MDNS_BACKEND=dns_sd`
+  Linux build (against `libavahi-compat-libdns_sd`) works but is not the default.
+
+- **`Static_avahi` has no effect in the `dns_sd` backend.** Avahi's static-file
+  publish mode (writing `/etc/avahi/hosts` and `/etc/avahi/services`) is specific
+  to Avahi on Linux; the `dns_sd` backend always registers services live. The
+  global remains defined so consumers link unchanged.
+
+- **Name resolution is backend-independent.** Role 1 uses `getaddrinfo()`, so
+  the `.local` name behavior documented in `docs/NETWORK-NOTES.md` is the same
+  regardless of which backend is compiled.
+
+---
+
+## 6. Verifying discovery
+
+Discovery needs no hardware — the `siggen` front end is sufficient.
+
+**Functional check (any platform):**
+
+1. Start a receiver: `radiod config/radiod@siggen.conf`.
+2. Run `control` with no target. It browses `_ka9q-ctl._udp`, lists the running
+   instance, and connects when selected.
+3. Cross-check with the platform's own browser:
+   - macOS: `dns-sd -B _ka9q-ctl._udp` then `dns-sd -L <name> _ka9q-ctl._udp`
+   - Linux: `avahi-browse -r _ka9q-ctl._udp`
+
+**Backend parity check (Linux):** because Linux can build either backend, it is
+the natural place to confirm the two are equivalent. Build once with
+`MDNS_BACKEND=avahi` and once with `MDNS_BACKEND=dns_sd` (the latter needs
+`libavahi-compat-libdns_sd`), and confirm `control` discovers the same instance
+— same name, host, address, and port — and connects successfully with each.
+
+---
+
+## 7. Source layout
+
+| File | Role |
+|------|------|
+| `src/avahi.h` | Provider-neutral service-discovery interface |
+| `src/avahi.c`, `src/avahi_browse.c` | `avahi` backend (Linux; exec avahi-* tools) |
+| `src/mdns.c` | `dns_sd` backend (macOS/FreeBSD; Bonjour API) |
+| `src/Makefile` | `MDNS_BACKEND` selection |
+
+The Linux backend is left intact; the portable backend is added alongside it and
+chosen at build time, so no consumer of the interface changes.

--- a/src/Makefile
+++ b/src/Makefile
@@ -62,6 +62,32 @@ else
   SOFLAGS += -shared
 endif
 
+# Service-discovery backend selection.
+# Linux uses the avahi-* CLI tools (avahi.c publish + avahi_browse.c browse);
+# other platforms use the portable dns_sd.h (Bonjour/mDNSResponder) backend
+# (mdns.c provides both). Override the auto choice with MDNS_BACKEND=avahi|dns_sd.
+MDNS_BACKEND ?= auto
+ifeq ($(MDNS_BACKEND),auto)
+  ifeq ($(UNAME_S),Linux)
+    MDNS_BACKEND = avahi
+  else
+    MDNS_BACKEND = dns_sd
+  endif
+endif
+
+ifeq ($(MDNS_BACKEND),dns_sd)
+  AVAHI_PUBLISH_OBJ = mdns.o
+  AVAHI_BROWSE_OBJ  = mdns.o
+  # dns_sd is in libSystem on macOS; FreeBSD (and a forced Linux/avahi-compat
+  # build) link it explicitly.
+  ifneq ($(UNAME_S),Darwin)
+    LDLIBS += -ldns_sd
+  endif
+else
+  AVAHI_PUBLISH_OBJ = avahi.o
+  AVAHI_BROWSE_OBJ  = avahi_browse.o
+endif
+
 IS_GCC_NOT_CLANG := $(shell \
 	$(CC) -dM -E - < /dev/null 2>/dev/null | \
 	awk '/__GNUC__/ { gcc=1 } /__clang__/ { clang=1 } END { if (gcc && !clang) print "yes" }')
@@ -93,14 +119,14 @@ LIBDSP = filter.o iir.o window.o osc.o sincospi.o sincospif.o
 LIBSTATUS = status.o decode_status.o
 
 # radiod uses a lot of unique objects. It should probably move to its own directory
-RADIOD_OBJECTS = main.o audio.o avahi.o modes.o fm.o wfm.o linear.o spectrum.o radio.o radio_status.o rtcp.o libdsp.a libstatus.a libradio.a
+RADIOD_OBJECTS = main.o audio.o $(AVAHI_PUBLISH_OBJ) modes.o fm.o wfm.o linear.o spectrum.o radio.o radio_status.o rtcp.o libdsp.a libstatus.a libradio.a
 
 ## source files for dependency generation (see DEPS=)
 # List every .c file in the tree so `-include $(DEPS)` picks up
 # header-change rebuild dependencies even for optional drivers
 # (bladerf, fobos, hackrf, hydrasdr, sdrplay, ...) whose targets
 # are gated by ENABLE_*.
-CFILES = airspy.c airspyhf.c aprs.c aprsfeed.c attr.c audio.c avahi.c avahi_browse.c ax25.c bandplan.c bladerf.c config.c control.c cwd.c decimate.c decode_status.c dump.c ezusb.c fcd.c fft-gen.c filter.c fm.c fobos.c funcube.c gauss.c hackrf.c hid-libusb.c hydrasdr.c iir.c jt-decoded.c linear.c main.c metadump.c misc.c modes.c monitor.c monitor-data.c monitor-display.c monitor-repeater.c morse.c multicast.c opusd.c opussend.c osc.c packetd.c pcmcat.c pcmrecord.c pcmsend.c pcmspawn.c ctcss.c powers.c radio.c radio_status.c rdsd.c rtcp.c rtlsdr.c rtp.c rx888.c rx888_boot.c sdrplay.c set_xcvr.c setfilt.c show-pkt.c show-sig.c si5351.c sig_gen.c spectrum.c status.c stereod.c sincospi.c sincospif.c tune.c wd-record.c wfm.c window.c
+CFILES = airspy.c airspyhf.c aprs.c aprsfeed.c attr.c audio.c avahi.c avahi_browse.c mdns.c ax25.c bandplan.c bladerf.c config.c control.c cwd.c decimate.c decode_status.c dump.c ezusb.c fcd.c fft-gen.c filter.c fm.c fobos.c funcube.c gauss.c hackrf.c hid-libusb.c hydrasdr.c iir.c jt-decoded.c linear.c main.c metadump.c misc.c modes.c monitor.c monitor-data.c monitor-display.c monitor-repeater.c morse.c multicast.c opusd.c opussend.c osc.c packetd.c pcmcat.c pcmrecord.c pcmsend.c pcmspawn.c ctcss.c powers.c radio.c radio_status.c rdsd.c rtcp.c rtlsdr.c rtp.c rx888.c rx888_boot.c sdrplay.c set_xcvr.c setfilt.c show-pkt.c show-sig.c si5351.c sig_gen.c spectrum.c status.c stereod.c sincospi.c sincospif.c tune.c wd-record.c wfm.c window.c
 
 HFILES = attr.h ax25.h bandplan.h conf.h config.h decimate.h ezusb.h fcd.h fcdhidcmd.h filter.h hidapi.h iir.h misc.h monitor.h morse.h multicast.h osc.h radio.h rx888.h si5351.h status.h config_paths.h
 
@@ -215,7 +241,7 @@ aprs: aprs.o ax25.o libdsp.a libradio.a
 aprsfeed: ax25.o aprsfeed.o libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-control: control.o bandplan.o modes.o avahi_browse.o libdsp.a libstatus.a libradio.a
+control: control.o bandplan.o modes.o $(AVAHI_BROWSE_OBJ) libdsp.a libstatus.a libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -liniparser -lncursesw $(LDLIBS)
 
 ctcss: ctcss.o libdsp.a libradio.a
@@ -236,13 +262,13 @@ metadump: metadump.o dump.o libstatus.a libradio.a
 monitor: monitor.o monitor-data.o monitor-display.o monitor-repeater.o morse.o libdsp.a libstatus.a libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lopus -lportaudio `pkg-config --silence-errors --libs alsa` -lsamplerate -liniparser  -lncursesw $(LDLIBS)
 
-opusd: opusd.o avahi.o libradio.a
+opusd: opusd.o $(AVAHI_PUBLISH_OBJ) libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lopus $(LDLIBS)
 
 opussend: opussend.o libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lopus -lportaudio $(LDLIBS)
 
-packetd: packetd.o ax25.o avahi.o libdsp.a libstatus.a libradio.a
+packetd: packetd.o ax25.o $(AVAHI_PUBLISH_OBJ) libdsp.a libstatus.a libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lfftw3f_threads -lfftw3f $(LDLIBS)
 
 pcmcat: pcmcat.o libradio.a
@@ -263,7 +289,7 @@ powers: powers.o dump.o libstatus.a libradio.a
 radiod: $(RADIOD_OBJECTS)
 	$(CC) -rdynamic $(LDFLAGS) -o $@ $^ -lopus -lfftw3f_threads -lfftw3f -liniparser -lusb-1.0 -ldl $(LDLIBS)
 
-rdsd: rdsd.o avahi.o libdsp.a libstatus.a libradio.a
+rdsd: rdsd.o $(AVAHI_PUBLISH_OBJ) libdsp.a libstatus.a libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lfftw3f_threads -lfftw3f $(LDLIBS)
 
 rx888_boot: rx888_boot.o ezusb.o
@@ -282,7 +308,7 @@ show-pkt: show-pkt.o libstatus.a libradio.a
 show-sig: show-sig.o libstatus.a libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lncursesw $(LDLIBS)
 
-stereod: stereod.o avahi.o libdsp.a libstatus.a libradio.a
+stereod: stereod.o $(AVAHI_PUBLISH_OBJ) libdsp.a libstatus.a libradio.a
 	$(CC) $(LDFLAGS) -o $@ $^ -lfftw3f_threads -lfftw3f $(LDLIBS)
 
 tune: tune.o libstatus.a libradio.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,13 +65,17 @@ endif
 # Service-discovery backend selection.
 # Linux uses the avahi-* CLI tools (avahi.c publish + avahi_browse.c browse);
 # other platforms use the portable dns_sd.h (Bonjour/mDNSResponder) backend
-# (mdns.c provides both). Override the auto choice with MDNS_BACKEND=avahi|dns_sd.
+# (mdns.c provides both). Override the auto choice with
+# MDNS_BACKEND=auto|avahi|dns_sd.
+# 'override' is required: a command-line MDNS_BACKEND= otherwise wins over these
+# assignments, so an explicit MDNS_BACKEND=auto would survive unresolved and
+# silently select the avahi backend even on platforms that have no avahi-* tools.
 MDNS_BACKEND ?= auto
 ifeq ($(MDNS_BACKEND),auto)
   ifeq ($(UNAME_S),Linux)
-    MDNS_BACKEND = avahi
+    override MDNS_BACKEND = avahi
   else
-    MDNS_BACKEND = dns_sd
+    override MDNS_BACKEND = dns_sd
   endif
 endif
 
@@ -83,9 +87,11 @@ ifeq ($(MDNS_BACKEND),dns_sd)
   ifneq ($(UNAME_S),Darwin)
     LDLIBS += -ldns_sd
   endif
-else
+else ifeq ($(MDNS_BACKEND),avahi)
   AVAHI_PUBLISH_OBJ = avahi.o
   AVAHI_BROWSE_OBJ  = avahi_browse.o
+else
+  $(error unknown MDNS_BACKEND '$(MDNS_BACKEND)'; expected one of: auto avahi dns_sd)
 endif
 
 IS_GCC_NOT_CLANG := $(shell \

--- a/src/avahi.h
+++ b/src/avahi.h
@@ -1,11 +1,12 @@
-#ifndef _AVAHI_H
-#include <avahi-client/client.h>
-#include <avahi-client/publish.h>
-#include <avahi-common/alternative.h>
-#include <avahi-common/simple-watch.h>
-#include <avahi-common/malloc.h>
-#include <avahi-common/error.h>
-#include <avahi-common/timeval.h>
+#ifndef AVAHI_H
+#define AVAHI_H 1
+
+// Provider-neutral service-discovery interface.
+// Implemented by avahi.c/avahi_browse.c (Linux, via avahi-* CLI tools) or by
+// mdns.c (dns_sd.h / Bonjour API, portable to macOS and FreeBSD). The build
+// system selects exactly one implementation; consumers include only this header.
+
+#include <stdbool.h>
 
 extern bool Static_avahi;
 
@@ -27,5 +28,5 @@ int avahi_browse(struct service_tab *table,int tabsize,char const *service_name)
 void avahi_free_service_table(struct service_tab *table,int tabsize);
 
 int avahi_start(char const *service_name,char const *service_type,int service_port,char const *dns_name,int base_address,char const *description);
-#define AVAHI_H 1
+
 #endif

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <arpa/inet.h>
 #include <net/if.h>
+#include <ifaddrs.h>
 #include <sys/select.h>
 #include "avahi.h"
 
@@ -355,6 +356,25 @@ static void browse_cb(DNSServiceRef sdRef,DNSServiceFlags flags,uint32_t ifindex
 		    serviceName,regtype,replyDomain,resolve_cb,c);
 }
 
+// True if 'name' is a loopback interface. Used to break ties when the same
+// instance is reported on more than one interface; see avahi_browse().
+static bool iface_is_loopback(char const *name){
+  if(name == NULL || *name == '\0')
+    return false;
+  struct ifaddrs *ifa = NULL;
+  if(getifaddrs(&ifa) != 0)
+    return false;
+  bool loopback = false;
+  for(struct ifaddrs *p = ifa; p != NULL; p = p->ifa_next){
+    if(p->ifa_name != NULL && strcmp(p->ifa_name,name) == 0){
+      loopback = (p->ifa_flags & IFF_LOOPBACK) != 0;
+      break;
+    }
+  }
+  freeifaddrs(ifa);
+  return loopback;
+}
+
 // Sort by instance name; NULLs to the end (matches avahi_browse.c).
 static int table_compare(void const *a,void const *b){
   struct service_tab const *t1 = a;
@@ -423,16 +443,29 @@ int avahi_browse(struct service_tab *table,int tabsize,char const *service_name)
   free(st.ctxs);
 
   // Sort and remove duplicate instance names (same policy as avahi_browse.c).
+  // mDNSResponder reports a locally published service on every interface it is
+  // visible on, including loopback, so the same instance routinely arrives more
+  // than once. control(1) passes the surviving row's ->interface straight to
+  // listen_mcast()/join_group(), where a loopback interface would silently cut
+  // it off from the network -- so when duplicates differ, keep a non-loopback
+  // one rather than whichever qsort happened to leave first.
   qsort(table,st.count,sizeof table[0],table_compare);
   int dupes = 0;
   for(int i = 0; i < st.count; i++){
     if(table[i].buffer == NULL || table[i].name == NULL)
       continue;
+    bool keep_is_loopback = iface_is_loopback(table[i].interface);
     for(int j = i+1; j < st.count; j++){
       if(table[j].buffer == NULL || table[j].name == NULL)
 	continue;
       if(strcmp(table[i].name,table[j].name) != 0)
 	break;
+      if(keep_is_loopback && !iface_is_loopback(table[j].interface)){
+	struct service_tab const tmp = table[i];   // promote the better row, discard the loopback one
+	table[i] = table[j];
+	table[j] = tmp;
+	keep_is_loopback = false;
+      }
       free(table[j].buffer);
       memset(&table[j],0,sizeof table[j]);
       dupes++;

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -1,0 +1,450 @@
+// Portable mDNS/DNS-SD implementation of the ka9q service-discovery interface
+// declared in avahi.h, built on the dns_sd.h (Bonjour/mDNSResponder) API.
+//
+// This is the counterpart to avahi.c/avahi_browse.c (which shell out to the
+// Linux avahi-* CLI tools). It lets radiod/control publish and browse services
+// through the dns_sd.h API instead, on any platform that provides it:
+//   - macOS   -- mDNSResponder, native in libSystem
+//   - FreeBSD -- mDNSResponder port
+//   - Linux   -- Avahi's mDNSResponder-compatible API (libavahi-compat-libdns_sd)
+// The build system selects exactly one backend. On Linux the native avahi CLI
+// backend is the default; this dns_sd backend is available there as a build
+// option (MDNS_BACKEND=dns_sd), though the Avahi compatibility shim is a less
+// complete dns_sd.h implementation than a full mDNSResponder (notably around
+// DNSServiceGetAddrInfo and shared connections).
+//
+// The three entry points intentionally keep the historical avahi_* names and
+// the exact struct service_tab allocation contract (all strings for one row
+// packed into a single ->buffer freed by avahi_free_service_table), so no
+// consumer needs to change.
+
+#include <dns_sd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <errno.h>
+#include <time.h>
+#include <pthread.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/select.h>
+#include "avahi.h"
+
+// Historical flag; the static-file publish mode (/etc/avahi/{hosts,services})
+// is Avahi-on-Linux specific and has no dns_sd equivalent, so this backend
+// always registers live. Defined here to satisfy the extern in avahi.h.
+bool Static_avahi;
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+static int64_t now_ms(void){
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC,&ts);
+  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+// ---------------------------------------------------------------------------
+// Publish side: avahi_start()
+//
+// All registrations share one DNSServiceCreateConnection() ref, serviced for
+// the life of the process by a single background thread pumping
+// DNSServiceProcessResult(). This is the in-process analog of the persistent
+// avahi-publish-service/-address child processes in avahi.c.
+// ---------------------------------------------------------------------------
+
+static pthread_mutex_t Reg_lock = PTHREAD_MUTEX_INITIALIZER;
+static DNSServiceRef Reg_conn = NULL;      // shared connection for all registrations
+static pthread_t Reg_thread;
+static bool Reg_running = false;
+
+static void reg_service_reply(DNSServiceRef sdRef,DNSServiceFlags flags,DNSServiceErrorType err,
+			      char const *name,char const *regtype,char const *domain,void *ctx){
+  (void)sdRef;(void)flags;(void)domain;(void)ctx;
+  if(err != kDNSServiceErr_NoError)
+    fprintf(stderr,"mdns: register '%s' %s failed: %d\n",name?name:"?",regtype?regtype:"?",err);
+}
+
+static void reg_record_reply(DNSServiceRef sdRef,DNSRecordRef rec,DNSServiceFlags flags,
+			     DNSServiceErrorType err,void *ctx){
+  (void)sdRef;(void)rec;(void)flags;(void)ctx;
+  if(err != kDNSServiceErr_NoError)
+    fprintf(stderr,"mdns: register address record failed: %d\n",err);
+}
+
+// Service the shared connection forever.
+static void *reg_pump(void *arg){
+  (void)arg;
+  for(;;){
+    pthread_mutex_lock(&Reg_lock);
+    int fd = Reg_conn ? DNSServiceRefSockFD(Reg_conn) : -1;
+    pthread_mutex_unlock(&Reg_lock);
+    if(fd < 0){
+      usleep(100000);
+      continue;
+    }
+    fd_set r;
+    FD_ZERO(&r);
+    FD_SET(fd,&r);
+    struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
+    int s = select(fd+1,&r,NULL,NULL,&tv);
+    if(s > 0 && FD_ISSET(fd,&r)){
+      pthread_mutex_lock(&Reg_lock);
+      if(Reg_conn)
+	DNSServiceProcessResult(Reg_conn);
+      pthread_mutex_unlock(&Reg_lock);
+    }
+  }
+  return NULL;
+}
+
+// Ensure the shared connection + pump thread exist. Caller holds Reg_lock.
+static int reg_ensure_conn(void){
+  if(Reg_conn != NULL)
+    return 0;
+  if(DNSServiceCreateConnection(&Reg_conn) != kDNSServiceErr_NoError){
+    Reg_conn = NULL;
+    return -1;
+  }
+  if(!Reg_running){
+    if(pthread_create(&Reg_thread,NULL,reg_pump,NULL) == 0){
+      pthread_detach(Reg_thread);
+      Reg_running = true;
+    }
+  }
+  return 0;
+}
+
+int avahi_start(char const *service_name,char const *service_type,int const service_port,
+		char const *dns_name,int address,char const *description){
+  if(service_name == NULL || service_type == NULL)
+    return -1;
+
+  pthread_mutex_lock(&Reg_lock);
+  if(reg_ensure_conn() != 0){
+    pthread_mutex_unlock(&Reg_lock);
+    fprintf(stderr,"mdns: DNSServiceCreateConnection failed\n");
+    return -1;
+  }
+
+  // Build TXT records: pid, description, source hostname -- mirrors avahi.c.
+  TXTRecordRef txt;
+  TXTRecordCreate(&txt,0,NULL);
+  {
+    char pidstr[16];
+    snprintf(pidstr,sizeof pidstr,"%d",(int)getpid());
+    TXTRecordSetValue(&txt,"pid",(uint8_t)strlen(pidstr),pidstr);
+
+    if(description != NULL && *description != '\0')
+      TXTRecordSetValue(&txt,"description",(uint8_t)strlen(description),description);
+
+    char hostname[256] = {0};
+    gethostname(hostname,sizeof hostname - 1);
+    TXTRecordSetValue(&txt,"source",(uint8_t)strlen(hostname),hostname);
+  }
+
+  DNSServiceRef svc = Reg_conn;   // sub-op on the shared connection
+  DNSServiceErrorType e = DNSServiceRegister(&svc,
+					     kDNSServiceFlagsShareConnection,
+					     0,                          // any interface
+					     service_name,
+					     service_type,
+					     NULL,                       // default domain (local)
+					     dns_name,                   // SRV target host
+					     htons((uint16_t)service_port),
+					     TXTRecordGetLength(&txt),
+					     TXTRecordGetBytesPtr(&txt),
+					     reg_service_reply,NULL);
+  TXTRecordDeallocate(&txt);
+  if(e != kDNSServiceErr_NoError){
+    pthread_mutex_unlock(&Reg_lock);
+    fprintf(stderr,"mdns: DNSServiceRegister('%s','%s') failed: %d\n",service_name,service_type,e);
+    return -1;
+  }
+
+  // Publish the name -> multicast-address A record (avahi.c's publish-address).
+  // 'address' is a host-order packed IPv4 quad ((a<<24)|(b<<16)|(c<<8)|d).
+  if(address != 0 && dns_name != NULL){
+    char fullname[256];
+    size_t n = strlen(dns_name);
+    if(n > 0 && dns_name[n-1] == '.')
+      snprintf(fullname,sizeof fullname,"%s",dns_name);           // already qualified
+    else if(strchr(dns_name,'.') != NULL)
+      snprintf(fullname,sizeof fullname,"%s.",dns_name);          // has a domain, add root dot
+    else
+      snprintf(fullname,sizeof fullname,"%s.local.",dns_name);    // bare host -> .local.
+
+    uint32_t rdata = htonl((uint32_t)address);
+    DNSRecordRef rec;
+    e = DNSServiceRegisterRecord(Reg_conn,&rec,
+				 kDNSServiceFlagsShared,
+				 0,
+				 fullname,
+				 kDNSServiceType_A,
+				 kDNSServiceClass_IN,
+				 sizeof rdata,&rdata,
+				 120,                    // ttl
+				 reg_record_reply,NULL);
+    if(e != kDNSServiceErr_NoError)
+      fprintf(stderr,"mdns: DNSServiceRegisterRecord('%s') failed: %d\n",fullname,e);
+  }
+  pthread_mutex_unlock(&Reg_lock);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Browse side: avahi_browse()
+//
+// dns_sd browse/resolve/getaddrinfo are async; avahi_browse() is synchronous
+// with a bounded timeout. We drive one shared connection through the pipeline
+//   DNSServiceBrowse -> DNSServiceResolve -> DNSServiceGetAddrInfo
+// collecting completed rows into the caller's table, then sort + de-dupe by
+// instance name exactly like avahi_browse.c.
+// ---------------------------------------------------------------------------
+
+struct browse_state {
+  struct service_tab *table;
+  int tabsize;
+  int count;
+  char const *service_name;
+  DNSServiceRef conn;
+  struct browse_ctx **ctxs;   // per-instance contexts to free at teardown
+  int nctx, capctx;
+};
+
+struct browse_ctx {
+  struct browse_state *st;
+  uint32_t ifindex;
+  char name[128];
+  char host[256];
+  char port[16];
+  char txt[512];
+};
+
+static char *append_str(char **w,char const *s){
+  char *start = *w;
+  size_t n = strlen(s) + 1;
+  memcpy(*w,s,n);
+  *w += n;
+  return start;
+}
+
+// Pack one resolved instance into the table using the single-buffer contract.
+static void add_entry(struct browse_state *st,char const *name,char const *host,
+		      char const *addr,char const *port,char const *iface,char const *txt){
+  if(st->count >= st->tabsize)
+    return;
+  char const *type = st->service_name;
+  size_t total = strlen("=")+1 + strlen(iface)+1 + strlen("IPv4")+1 + strlen(name)+1
+    + strlen(type)+1 + strlen("local")+1 + strlen(host)+1 + strlen(addr)+1
+    + strlen(port)+1 + strlen(txt)+1;
+  char *buf = malloc(total);
+  if(buf == NULL)
+    return;
+  char *w = buf;
+  struct service_tab *tp = &st->table[st->count];
+  memset(tp,0,sizeof *tp);
+  tp->buffer    = buf;
+  tp->line_type = append_str(&w,"=");
+  tp->interface = append_str(&w,iface);
+  tp->protocol  = append_str(&w,"IPv4");
+  tp->name      = append_str(&w,name);
+  tp->type      = append_str(&w,type);
+  tp->domain    = append_str(&w,"local");
+  tp->dns_name  = append_str(&w,host);
+  tp->address   = append_str(&w,addr);
+  tp->port      = append_str(&w,port);
+  tp->txt       = append_str(&w,txt);
+  st->count++;
+}
+
+static void flatten_txt(uint16_t len,void const *rec,char *out,size_t outsize){
+  out[0] = '\0';
+  if(rec == NULL || len == 0)
+    return;
+  uint16_t count = TXTRecordGetCount(len,rec);
+  size_t used = 0;
+  for(uint16_t i = 0; i < count; i++){
+    char key[256];
+    uint8_t vlen = 0;
+    void const *val = NULL;
+    if(TXTRecordGetItemAtIndex(len,rec,i,sizeof key,key,&vlen,&val) != kDNSServiceErr_NoError)
+      break;
+    int w = snprintf(out+used,outsize-used,"%s%s=%.*s",used?" ":"",key,(int)vlen,val?(char const *)val:"");
+    if(w < 0 || (size_t)w >= outsize-used)
+      break;
+    used += w;
+  }
+}
+
+static int track_ctx(struct browse_state *st,struct browse_ctx *c){
+  if(st->nctx == st->capctx){
+    int cap = st->capctx ? st->capctx * 2 : 16;
+    struct browse_ctx **p = realloc(st->ctxs,cap * sizeof *p);
+    if(p == NULL)
+      return -1;
+    st->ctxs = p;
+    st->capctx = cap;
+  }
+  st->ctxs[st->nctx++] = c;
+  return 0;
+}
+
+static void addr_cb(DNSServiceRef sdRef,DNSServiceFlags flags,uint32_t ifindex,
+		    DNSServiceErrorType err,char const *hostname,
+		    struct sockaddr const *address,uint32_t ttl,void *ctx){
+  (void)sdRef;(void)flags;(void)ifindex;(void)hostname;(void)ttl;
+  struct browse_ctx *c = ctx;
+  if(err != kDNSServiceErr_NoError || address == NULL || address->sa_family != AF_INET)
+    return;
+  char ip[INET_ADDRSTRLEN] = "";
+  struct sockaddr_in const *sin = (struct sockaddr_in const *)address;
+  inet_ntop(AF_INET,&sin->sin_addr,ip,sizeof ip);
+
+  char ifname[IF_NAMESIZE] = "";
+  if(c->ifindex != 0)
+    if_indextoname(c->ifindex,ifname);
+
+  char host[256];
+  snprintf(host,sizeof host,"%s",c->host);
+  size_t hl = strlen(host);
+  if(hl > 0 && host[hl-1] == '.')         // strip trailing root dot for display
+    host[hl-1] = '\0';
+
+  add_entry(c->st,c->name,host,ip,c->port,ifname,c->txt);
+}
+
+static void resolve_cb(DNSServiceRef sdRef,DNSServiceFlags flags,uint32_t ifindex,
+		       DNSServiceErrorType err,char const *fullname,char const *hosttarget,
+		       uint16_t port,uint16_t txtLen,unsigned char const *txtRecord,void *ctx){
+  (void)sdRef;(void)flags;(void)fullname;
+  struct browse_ctx *c = ctx;
+  if(err != kDNSServiceErr_NoError)
+    return;
+  snprintf(c->host,sizeof c->host,"%s",hosttarget);
+  snprintf(c->port,sizeof c->port,"%u",(unsigned)ntohs(port));
+  flatten_txt(txtLen,txtRecord,c->txt,sizeof c->txt);
+  c->ifindex = ifindex;
+
+  DNSServiceRef r = c->st->conn;
+  DNSServiceGetAddrInfo(&r,kDNSServiceFlagsShareConnection,ifindex,
+			kDNSServiceProtocol_IPv4,hosttarget,addr_cb,c);
+}
+
+static void browse_cb(DNSServiceRef sdRef,DNSServiceFlags flags,uint32_t ifindex,
+		      DNSServiceErrorType err,char const *serviceName,
+		      char const *regtype,char const *replyDomain,void *ctx){
+  (void)sdRef;
+  struct browse_state *st = ctx;
+  if(err != kDNSServiceErr_NoError || !(flags & kDNSServiceFlagsAdd))
+    return;
+  struct browse_ctx *c = calloc(1,sizeof *c);
+  if(c == NULL)
+    return;
+  c->st = st;
+  snprintf(c->name,sizeof c->name,"%s",serviceName);
+  if(track_ctx(st,c) != 0){
+    free(c);
+    return;
+  }
+  DNSServiceRef r = st->conn;
+  DNSServiceResolve(&r,kDNSServiceFlagsShareConnection,ifindex,
+		    serviceName,regtype,replyDomain,resolve_cb,c);
+}
+
+// Sort by instance name; NULLs to the end (matches avahi_browse.c).
+static int table_compare(void const *a,void const *b){
+  struct service_tab const *t1 = a;
+  struct service_tab const *t2 = b;
+  if(t2 == NULL || t2->name == NULL)
+    return -1;
+  if(t1 == NULL || t1->name == NULL)
+    return +1;
+  return strcmp(t1->name,t2->name);
+}
+
+int avahi_browse(struct service_tab *table,int tabsize,char const *service_name){
+  if(service_name == NULL || *service_name == '\0' || table == NULL || tabsize <= 0)
+    return 0;
+  memset(table,0,sizeof(*table) * tabsize);
+
+  struct browse_state st = {0};
+  st.table = table;
+  st.tabsize = tabsize;
+  st.service_name = service_name;
+
+  if(DNSServiceCreateConnection(&st.conn) != kDNSServiceErr_NoError)
+    return 0;
+
+  DNSServiceRef browse = st.conn;
+  if(DNSServiceBrowse(&browse,kDNSServiceFlagsShareConnection,0,
+		      service_name,NULL,browse_cb,&st) != kDNSServiceErr_NoError){
+    DNSServiceRefDeallocate(st.conn);
+    return 0;
+  }
+
+  int fd = DNSServiceRefSockFD(st.conn);
+  int64_t const start = now_ms();
+  int64_t last_event = start;
+  int64_t const budget = 2500;   // total ms to wait for discovery
+  int64_t const idle   = 600;    // stop early after this much quiet once we have results
+
+  for(;;){
+    int64_t const t = now_ms();
+    int64_t const elapsed = t - start;
+    if(elapsed >= budget)
+      break;
+    if(st.count > 0 && (t - last_event) >= idle)
+      break;
+
+    int64_t remaining = budget - elapsed;
+    int64_t slice = remaining < 200 ? remaining : 200;
+    struct timeval tv = { .tv_sec = slice/1000, .tv_usec = (slice%1000)*1000 };
+    fd_set r;
+    FD_ZERO(&r);
+    FD_SET(fd,&r);
+    int s = select(fd+1,&r,NULL,NULL,&tv);
+    if(s > 0 && FD_ISSET(fd,&r)){
+      if(DNSServiceProcessResult(st.conn) != kDNSServiceErr_NoError)
+	break;
+      last_event = now_ms();
+    } else if(s < 0 && errno != EINTR){
+      break;
+    }
+  }
+
+  // Deallocating the shared connection cleans up all sub-operations.
+  DNSServiceRefDeallocate(st.conn);
+  for(int i = 0; i < st.nctx; i++)
+    free(st.ctxs[i]);
+  free(st.ctxs);
+
+  // Sort and remove duplicate instance names (same policy as avahi_browse.c).
+  qsort(table,st.count,sizeof table[0],table_compare);
+  int dupes = 0;
+  for(int i = 0; i < st.count; i++){
+    if(table[i].buffer == NULL || table[i].name == NULL)
+      continue;
+    for(int j = i+1; j < st.count; j++){
+      if(table[j].buffer == NULL || table[j].name == NULL)
+	continue;
+      if(strcmp(table[i].name,table[j].name) != 0)
+	break;
+      free(table[j].buffer);
+      memset(&table[j],0,sizeof table[j]);
+      dupes++;
+    }
+  }
+  qsort(table,st.count,sizeof table[0],table_compare);
+  return st.count - dupes;
+}
+
+// Free the per-row buffers; caller owns the table array itself.
+void avahi_free_service_table(struct service_tab *table,int tabsize){
+  for(int i = 0; i < tabsize; i++)
+    free(table[i].buffer);
+  memset(table,0,sizeof(*table) * tabsize);
+}


### PR DESCRIPTION
## Portable service discovery: add a `dns_sd.h` backend for mDNS

Makes ka9q-radio's mDNS-based service discovery build and run on macOS and
FreeBSD, without changing its behavior on Linux. Reference documentation for the
design lives in `docs/PORTABLE-MDNS.md`; this description covers the change set
and its verification status.

### Motivation

On Linux, publish/browse are implemented by `avahi.c` / `avahi_browse.c`, which
`fork`/`exec` the `avahi-publish-service`, `avahi-publish-address`, and
`avahi-browse` CLI tools. Those tools don't exist on macOS or FreeBSD, so
publish/browse fail there — the concrete reason the macOS build was incomplete.
Both platforms ship the `dns_sd.h` (Bonjour / mDNSResponder) API, which speaks
the same mDNS wire protocol, so a second backend covers them with one body of
portable code.

### Approach

A provider-neutral interface (`avahi.h`) backed by either of two build-selected
backends. The Linux `avahi` backend is left byte-for-byte intact; a new
`dns_sd` backend (`mdns.c`) is added alongside and selected automatically per
platform. No consumer of the interface changes.

### Commits

| Commit | Change |
|--------|--------|
| `avahi.h` de-couple | Strip vestigial `avahi-client/*` / `avahi-common/*` includes (no code references any libavahi symbol); make the header self-contained (`#include <stdbool.h>`, fixed include guard). Zero consumer edits. |
| add `mdns.c` | `dns_sd.h` backend implementing `avahi_start` / `avahi_browse` / `avahi_free_service_table`: `DNSServiceRegister` + `DNSServiceRegisterRecord` publish, async→sync `Browse→Resolve→GetAddrInfo` bridge, persistent-registration thread, same `service_tab` single-buffer alloc/free contract and sort/de-dupe policy as the avahi backend. |
| Makefile backend selection | `MDNS_BACKEND` auto-selection (Linux→avahi, else→dns_sd; overridable); backends referenced via `$(AVAHI_PUBLISH_OBJ)` / `$(AVAHI_BROWSE_OBJ)`; `-ldns_sd` linked off-Darwin. |
| docs | `docs/PORTABLE-MDNS.md` reference documentation. |

### Diff surface

Upstream files touched are minimal: `src/avahi.h` (~10 lines) and `src/Makefile`
(backend selection). `src/avahi.c` and `src/avahi_browse.c` are unchanged. New
files: `src/mdns.c`, `docs/PORTABLE-MDNS.md`.

### Verification

- **Publish→browse round trip** smoke-tested on macOS against the live
  mDNSResponder: a service registered via `avahi_start()` (service + A record +
  TXT) is found by `avahi_browse()` with correct name, host, resolved numeric
  address, port, interface, and TXT records — the exact fields `control.c` feeds
  into `getaddrinfo(..., AI_NUMERICHOST)`.
- **No-match path** returns 0 within the time budget; freeing an all-zero table
  is safe.
- Clean under the runtime **AddressSanitizer / UndefinedBehaviorSanitizer**
  bug-detectors on both paths (validates the single-buffer pack/free contract).
- `mdns.o` builds warning-free under project `CFLAGS` (`-Wall -Wextra`);
  `make -n` confirms correct object/flag selection for Darwin, Linux, and
  forced-`dns_sd` configurations.

### Still open/ToDo

- **End-to-end parity test against a running `radiod`** (A/B the `avahi` vs
  `dns_sd` backends discovering a live instance via `control`). Runnable on
  Linux today; a full on-macOS run is gated on the remaining non-mDNS
  portability work (`<bsd/string.h>` compat shim and the `multicast.c`
  Linux-header dependency).