### PR TITLE
Fix SANITIZE option

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -70,9 +70,9 @@ IS_GCC_NOT_CLANG := $(shell \
 HAS_PIGPIO := $(shell printf '\043include <pigpio.h>\n' | $(CC) $(CPPFLAGS) -E - >/dev/null 2>&1 && echo 1)
 
 ifeq ($(BUILD),debug)
-     DOPTS = -g
+     DOPTS += -g
 else
-     DOPTS = -DNDEBUG=1 -O3
+     DOPTS += -DNDEBUG=1 -O3
 endif
 
 ifeq ($(NATIVE),1)


### PR DESCRIPTION
It looks like ebcbdc3e9f970101f2313759bccf1c5d7886c2af broke the `SANITIZE` build option, because `DOPTS += -fsanitize=address -fsanitize=undefined` was moved above the lines that overwrite `DOPTS` when setting debug flags. To solve this, I modified the debug lines to append to `DOPTS` rather than overwriting it.