### PR TITLE
Include `<string.h>` in the files that call string functions

### DIFF
--- a/src/airspy.c
+++ b/src/airspy.c
@@ -8,6 +8,7 @@
 #include <libairspy/airspy.h>
 #include <errno.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/airspyhf.c
+++ b/src/airspyhf.c
@@ -8,6 +8,7 @@
 #include <libairspyhf/airspyhf.h>
 #include <errno.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/bladerf.c
+++ b/src/bladerf.c
@@ -6,6 +6,8 @@
 #include <libbladeRF.h>
 #include <errno.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
+#include <strings.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/fobos.c
+++ b/src/fobos.c
@@ -17,6 +17,7 @@ on a per-channel basis by selecting output filter type BEAM and calling set_filt
 #include <iniparser/iniparser.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/funcube.c
+++ b/src/funcube.c
@@ -6,6 +6,7 @@
 #include <portaudio.h>
 #include <errno.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/hydrasdr.c
+++ b/src/hydrasdr.c
@@ -8,6 +8,7 @@
 #include <libhydrasdr/hydrasdr.h>
 #include <errno.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -19,6 +19,7 @@
 #include <stdlib.h> // for ldiv(), free()
 #include <stdbool.h>
 #include <sys/errno.h>
+#include <string.h>
 #ifdef __linux__
 #include <bsd/string.h>
 #endif

--- a/src/rtlsdr.c
+++ b/src/rtlsdr.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <iniparser/iniparser.h>
 #include <sysexits.h>
+#include <string.h>
 #include <strings.h>
 #include <stdatomic.h>
 #include <unistd.h>

--- a/src/rx888.c
+++ b/src/rx888.c
@@ -14,6 +14,7 @@
 #include <pthread.h>
 #include <libusb-1.0/libusb.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/rx888_boot.c
+++ b/src/rx888_boot.c
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include <libusb-1.0/libusb.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/sdrplay.c
+++ b/src/sdrplay.c
@@ -15,6 +15,8 @@
 #include <errno.h>
 #include <unistd.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
+#include <strings.h>
 #if defined(linux)
 #include <bsd/string.h>
 #endif

--- a/src/sig_gen.c
+++ b/src/sig_gen.c
@@ -7,6 +7,7 @@
 //#include <portaudio.h>
 #include <errno.h>
 #include <iniparser/iniparser.h>
+#include <string.h>
 #if defined(linux)
 #include <bsd/string.h>
 #include <bsd/stdlib.h>


### PR DESCRIPTION
Eleven files in src/ call `strlcpy`, `strncpy`, `strcmp`, `strstr`, `strtok`, `strdup` and `memset` without including `<string.h>`. They compile today, but only as a side effect: they include `<bsd/string.h>` to get `strlcpy`, and that header pulls in `<string.h>` behind them. The include sits behind `#if defined(linux)`.

So the declarations for the standard string functions are currently supplied by a conditional include of a non-standard header that was added for a different function. Nothing in these files asks explicitly for `<string.h>`, and nothing guarantees it keeps arriving.

A twelfth file, `rtlsdr.c`, has the same omission without even that much: it calls `strlcpy` at two sites and includes no string header at all, reaching `<bsd/string.h>` indirectly through misc.h. It is fixed here alongside the other eleven, and it shows what the pattern degenerates into once the declaration is two headers away from the call.

**Why this is worth fixing rather than leaving alone**

The declarations are load-bearing, and nothing holds them up. The guard exists because of `strlcpy`, which is the one function `<string.h>` could not supply on `glibc`. That makes every string declaration in these files dependent on the `libbsd` dependency continuing to exist and continuing to be included first. glibc 2.38 (July 2023) added `strlcpy` and `strlcat` to `libc`, so dropping `-lbsd` is now a plausible cleanup — and the day it happens, twelve files silently lose the declarations for `strncpy`, `strcmp`, `strstr` and `memset` along with it. This patch makes that a safe change instead of a trap.

Implicit declarations are not a benign warning here. If `<string.h>` is ever not reached, the compiler assumes an `int` return, and on a 64-bit target the top half of every returned pointer is discarded. Three calls would consume such a pointer: `strtok` in `fobos.c`, `strdup` in `sig_gen.c` and `strstr` in `funcube.c`. The `strncpy` and `memset` calls discard their returns and would be unaffected. Recent clang rejects implicit declarations outright rather than warning, so on a current toolchain this surfaces as a build failure rather than as quiet corruption — but the corruption is the failure mode wherever the compiler is more permissive.

Include what you use. A file that calls memset should say so. This is the ordinary rule, and these twelve files are the exceptions to it in `src/`.

**What the patch does**
  
Adds `#include <string.h>` to the twelve files that call these functions, and `<strings.h>` to `bladerf.c` and `sdrplay.c` for `strcasecmp` — the nine other driver files already include `<strings.h>` explicitly, so this just makes the set uniform.

14 added lines, all `#include`. No conditionals, no new dependencies, no configuration, nothing removed. On Linux nothing changes: `<bsd/string.h>` includes `<string.h>` itself, so the declarations were already arriving and are identical afterwards. `<bsd/string.h>` and `-lbsd` are left exactly as they are.

**Testing**

These edits are carried on a working branch of mine, where the twelve files have the same include state as here. On that branch make and make install both complete cleanly on Ubuntu 24.04, and the installed `radiod`, `control` and `monitor` were each run afterwards to print their version banner — so the change is exercised through to a loaded, executing binary, not just to a successful compile.

**Scope**
  
I checked the rest of `src/` rather than only the files I happened to touch. `fft-gen.c`, `filter.c` and `osc.c` also call `memset`/`memcpy`/`strerror` without `<string.h>`, but they include `<memory.h>`, which is `#include <string.h>` and nothing else, so they already receive it and are not part of this. `radio.h` mentions `memcpy` only in a comment. That accounts for every caller in the tree.

Found while building outside Debian, where the `#if defined(linux)` guard is false and the missing declarations become visible immediately. But this is not a portability patch: nothing here is conditional, nothing is platform-specific, and the change stands on its own on Linux. It is the kind of thing that is invisible right up until it isn't.