### PR TITLE
Remove the unused `<uuid/uuid.h>` and the `uuid-dev` dependency behind it

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Phil Karn <karn@ka9q.net>
 Rules-Requires-Root: no
 Build-Depends: make, gcc, debhelper-compat (= 13),
  libbsd-dev, libfftw3-dev, libopus-dev, libiniparser-dev,
- libavahi-client-dev, uuid-dev, libncurses-dev, libusb-1.0-0-dev,
+ libavahi-client-dev, libncurses-dev, libusb-1.0-0-dev,
  portaudio19-dev, libsamplerate-dev, libogg-dev, libairspy-dev,
  libairspyhf-dev, libbladerf-dev, libfobos-dev, libhackrf-dev,
  libhydrasdr-dev, librtlsdr-dev

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@ However, I'm interested in fixing any unnecessary non-portabilities.
 To build and install this package on Debian (including the Raspberry Pi), install the prerequisite packages:
 
 ```
-sudo apt install git avahi-utils build-essential make gcc libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev portaudio19-dev libasound2-dev uuid-dev rsync libogg-dev libsamplerate-dev libliquid-dev libncursesw5-dev libhackrf-dev libbladerf-dev libhydrasdr-dev libfobos-dev
+sudo apt install git avahi-utils build-essential make gcc libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev portaudio19-dev libasound2-dev rsync libogg-dev libsamplerate-dev libliquid-dev libncursesw5-dev libhackrf-dev libbladerf-dev libhydrasdr-dev libfobos-dev
 ```
 
 (libliquid-dev isn't actually used yet, but it probably will be soon.)

--- a/src/radio.c
+++ b/src/radio.c
@@ -31,7 +31,6 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <pwd.h>
-#include <uuid/uuid.h>
 #include <fcntl.h>
 #include <sysexits.h>
 #include <ctype.h>


### PR DESCRIPTION
`src/radio.c` includes `<uuid/uuid.h>`. Nothing in the tree uses it: there are no `uuid_*` calls anywhere, no `uuid_t` or any other uuid type, and no target links `-luuid`. It is the only uuid reference in the source.

The cost is not the include itself but what it drags along. `uuid-dev` is in `debian/control`'s Build-Depends and in the `apt install` line in `docs/INSTALL.md`, so everyone who builds from source installs a package the build has never used.

**Two commits, deliberately separate**

1. Remove the include — one deleted line in `src/radio.c`. Self-contained, and correct whether or not you want the second.
2. Drop the dependency — `uuid-dev` out of `debian/control` and `docs/INSTALL.md`. This is only safe because of the first.

Split so the second can be dropped or deferred without losing the first.

**Testing**

Built and installed on Ubuntu 24.04 with `uuid-dev` not present on the machine — apt had to fetch it previously, so it is not part of the base image and its absence is real. `radiod`, `control` and `monitor` were each run afterwards to print their version banner. Had anything still needed the header, the build would have failed at the `#include`.

One honest gap: this exercises the make build, not the Debian packaging. I have not run `dpkg-buildpackage`, so the debian/control change rests on the source audit above rather than on a package build.
