### PR TITLE
Add $(LDFLAGS) to the driver plugin link rules

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -294,37 +294,37 @@ wd-record: wd-record.o libstatus.a attr.o libradio.a
 
 ## Dynamically loaded modules for SDR front ends
 funcube.so: funcube.o fcd.o hid-libusb.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lportaudio -lusb-1.0 $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lportaudio -lusb-1.0 $(LDLIBS)
 
 rx888.so: rx888.o si5351.o ezusb.o hid-libusb.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lusb-1.0 $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lusb-1.0 $(LDLIBS)
 
 airspy.so: airspy.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lairspy $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lairspy $(LDLIBS)
 
 airspyhf.so: airspyhf.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lairspyhf $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lairspyhf $(LDLIBS)
 
 hydrasdr.so: hydrasdr.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lhydrasdr $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lhydrasdr $(LDLIBS)
 
 rtlsdr.so: rtlsdr.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lrtlsdr $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lrtlsdr $(LDLIBS)
 
 sdrplay.so: sdrplay.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lsdrplay_api $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lsdrplay_api $(LDLIBS)
 
 fobos.so: fobos.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lfobos $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lfobos $(LDLIBS)
 
 hackrf.so: hackrf.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lhackrf -lusb-1.0 $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lhackrf -lusb-1.0 $(LDLIBS)
 
 bladerf.so: bladerf.o
-	$(CC) $(SOFLAGS) -o $@ $^ -lbladeRF $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lbladeRF $(LDLIBS)
 
 sig_gen.so: sig_gen.o gauss.o libradio.a
-	$(CC) $(SOFLAGS) -o $@ $^ -lsamplerate $(LDLIBS)
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $^ -lsamplerate $(LDLIBS)
 
 # subroutines useful in more than one program
 # subroutines useful in more than one program
@@ -360,7 +360,7 @@ config_paths.h: Makefile
 	@printf '#endif\n' >> $@
 
 %.so: %.o
-	$(CC) $(SOFLAGS) -o $@ $<
+	$(CC) $(LDFLAGS) $(SOFLAGS) -o $@ $<
 
 %.o: %.c config_paths.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
The twelve `.so` rules in `src/Makefile` link as

      `$(CC) $(SOFLAGS) -o $@ $^ -lairspy $(LDLIBS)`

with no `$(LDFLAGS)`. All twenty-nine executable rules in the same file include it. `LDFLAGS` is where the `-L` search paths live, so the plugins are linked without them.

Two things in the Makefile already depend on `LDFLAGS` reaching the link, and neither has ever worked for a driver.

`SANITIZE=1` has never applied to any plugin. It adds `-fsanitize=address` `-fsanitize=undefined` to both `DOPTS` and `LDFLAGS`. The plugins get the compile half and not the link half. Every driver is therefore unsanitized in a build that reports itself as sanitized, which is the failure mode you least want from that flag.

The Darwin arm's MacPorts search path is dropped. `LDFLAGS += -L/opt/local/lib` is added specifically so the build can find MacPorts libraries — and the twelve rules that need it are the twelve that discard it.

A user's environment `LDFLAGS` goes the same way, since `LDFLAGS ?=` inherits it.

`make -n` for one plugin, before and after:

before:  `cc  -bundle ... -o airspy.so airspy.o -lairspy -lm -lpthread ...`
after:   `cc -fsanitize=address -fsanitize=undefined -L/opt/local/lib \`
                `-bundle ... -o airspy.so airspy.o -lairspy ...`

**What the patch does**

Inserts `$(LDFLAGS)` into the twelve `.so` rules, positioned as it is in the executable rules — `$(CC) $(LDFLAGS)  $(SOFLAGS) -o $@` .... Twelve lines, no other change.

Nothing changes on Debian in the ordinary case: the vendor libraries are already on the default search path, and `LDFLAGS` is empty unless `SANITIZE` is set or the environment supplies one. The visible difference on Debian is that `SANITIZE=1` starts doing what it says.

**Testing**

The same rule form is carried on a working branch of mine, where `make` and `make install` complete cleanly on Ubuntu 24.04 and the installed `radiod`, `control` and `monitor` each run and print their version banner.

Two limits worth stating. That branch is not byte-identical here: three of the twelve rules there also use a `$(LIBUSB)` variable in place of `-lusb-1.0`, which is unrelated and not part of this. And the `make -n` output above was taken on Darwin, where I have no MacPorts libraries installed — so it shows the search path is absent from the link command, not that the link fails for want of it.
