### PR TITLE
Remove the unused Avahi headers from `avahi.h`, and fix its include guard

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Phil Karn <karn@ka9q.net>
 Rules-Requires-Root: no
 Build-Depends: make, gcc, debhelper-compat (= 13),
  libbsd-dev, libfftw3-dev, libopus-dev, libiniparser-dev,
- libavahi-client-dev, uuid-dev, libncurses-dev, libusb-1.0-0-dev,
+ uuid-dev, libncurses-dev, libusb-1.0-0-dev,
  portaudio19-dev, libsamplerate-dev, libogg-dev, libairspy-dev,
  libairspyhf-dev, libbladerf-dev, libfobos-dev, libhackrf-dev,
  libhydrasdr-dev, librtlsdr-dev

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@ However, I'm interested in fixing any unnecessary non-portabilities.
 To build and install this package on Debian (including the Raspberry Pi), install the prerequisite packages:
 
 ```
-sudo apt install git avahi-utils build-essential make gcc libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev portaudio19-dev libasound2-dev uuid-dev rsync libogg-dev libsamplerate-dev libliquid-dev libncursesw5-dev libhackrf-dev libbladerf-dev libhydrasdr-dev libfobos-dev
+sudo apt install git avahi-utils build-essential make gcc libairspy-dev libairspyhf-dev libbsd-dev libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev portaudio19-dev libasound2-dev uuid-dev rsync libogg-dev libsamplerate-dev libliquid-dev libncursesw5-dev libhackrf-dev libbladerf-dev libhydrasdr-dev libfobos-dev
 ```
 
 (libliquid-dev isn't actually used yet, but it probably will be soon.)

--- a/src/avahi.h
+++ b/src/avahi.h
@@ -1,11 +1,10 @@
-#ifndef _AVAHI_H
-#include <avahi-client/client.h>
-#include <avahi-client/publish.h>
-#include <avahi-common/alternative.h>
-#include <avahi-common/simple-watch.h>
-#include <avahi-common/malloc.h>
-#include <avahi-common/error.h>
-#include <avahi-common/timeval.h>
+#ifndef AVAHI_H
+#define AVAHI_H 1
+
+// No Avahi library headers are needed here. avahi.c and avahi_browse.c
+// implement this interface by running the avahi-* command line tools, so no
+// Avahi type or symbol appears in either the interface or the implementation.
+#include <stdbool.h> // for Static_avahi
 
 extern bool Static_avahi;
 
@@ -27,5 +26,5 @@ int avahi_browse(struct service_tab *table,int tabsize,char const *service_name)
 void avahi_free_service_table(struct service_tab *table,int tabsize);
 
 int avahi_start(char const *service_name,char const *service_type,int service_port,char const *dns_name,int base_address,char const *description);
-#define AVAHI_H 1
+
 #endif


### PR DESCRIPTION
`src/avahi.h` includes seven Avahi development headers. Nothing that is built uses an Avahi type or symbol — `avahi.c` says so itself on line 2, "Version that just forks and execs the commands 'avahi-browse' or 'avahi-publish'", and that is what it does: `execlp("avahi-publish-service", ...)`. Nothing links `-lavahi-*` either.

To get ahead of the obvious grep: `src/old/old-avahi.c` does use `AvahiClient`, `AvahiEntryGroup` and friends. It is the older library-based implementation, and `src/old/` appears nowhere in `src/Makefile`, so it is not built and not affected by this.

**The include guard has never worked**

```
1:   #ifndef _AVAHI_H
30:  #define AVAHI_H 1
31:  #endif
```

It tests `_AVAHI_H` and defines `AVAHI_H`. Including the header twice in one translation unit is an error today:

`avahi.h:12:8: error: redefinition of 'service_tab'`

Nothing happens to trip that at the moment, which is exactly why it has survived.

**Two commits, deliberately separate**

1. **Fix the header** — correct the guard to test and define the same name, drop the seven Avahi includes, and add `<stdbool.h>`. That last one is required rather than tidiness: the header declares `extern bool Static_avahi` and was getting bool transitively from the Avahi headers, so removing them without it would break the header. One file, no interface change.
2. **Drop `libavahi-client-dev`** from `debian/control`'s Build-Depends and from the apt install line in `docs/INSTALL.md`. With the includes gone nothing in the build uses it — no source includes an Avahi header, no target links `-lavahi-*`.

Split so the second can be dropped or deferred without losing the first.

This is the -dev package only. `avahi-publish-service` and `avahi-browse` come from `avahi-utils`, which `avahi.c` execs at runtime; that stays a Depends: on `ka9q-radio-control` and stays in the apt line.

**Testing**

Checked directly, on a machine with no Avahi installed at all: the header now compiles standalone, and twice in one translation unit without error. Before the patch the second of those is the redefinition of `service_tab` above.

The same header change is carried on a working branch of mine where make and make install complete cleanly on Ubuntu 24.04 and the installed binaries run. That branch's copy differs in one respect, a comment describing the interface as provider-neutral, which belongs to unrelated work and is not here.

For the second commit, both changes are also carried on that branch with `libavahi-client-dev` removed from the machine's package list entirely, and make, make install and the binaries all still work. The absence is real rather than nominal: on an earlier build apt had to fetch and unpack the package, so it is not part of the base image.

That tests the make build without the package. It does not test `debian/control` itself, since I have not run `dpkg-buildpackage` — that file's correctness still rests on there being no Avahi header included and no `-lavahi-*` linked anywhere.
