### PR TITLE
Fix RX888 fractional sample rate calculation

### DIFF
--- a/src/rx888.c
+++ b/src/rx888.c
@@ -1270,8 +1270,8 @@ static double rx888_set_samprate(struct sdrstate *sdr, double const samprate){
 
   si5351_pvals_t ms = {0};
   si5351_get_ms_pvals(&best,&ms);
-  // fout is for display only
-  double const fout = vco / (best.R * (best.D + best.E/best.F));
+  // Calculate actual output sample rate
+  double const fout = vco / (best.R * (best.D + (double)best.E / best.F));
   fprintf(stderr,"RX888 Si5351 output divider: samprate = vco / (%'u*(%'u + %'u/%'u)) = %'lf Hz",
 	  best.R, best.D, best.E, best.F, fout);
   fprintf(stderr,"; P1=%u, P2=%u, P3=%u\n", ms.P1, ms.P2, ms.P3);


### PR DESCRIPTION
## Summary

Fix an integer division error in the RX888 Si5351 output sample rate
calculation.

The expression:

``` c
best.E / best.F
```

performs integer division before being included in the floating-point
calculation of `fout`. For fractional Si5351 output divisors this
truncates the fractional component, causing `rx888_set_samprate()` to
return an incorrect sample rate.

Although the existing comment described `fout` as being "for display
only", the value is returned by `rx888_set_samprate()` and is
subsequently used as the frontend sample rate, so the incorrect value
has functional consequences.

The fix explicitly converts `best.E` to `double` before division:

``` c
(double)best.E / best.F
```

and updates the adjacent comment accordingly.

## Reproduction

This was observed with an RX888 using:

``` ini
reference = 27000465.48
samprate = 64800000
```

The calculated Si5351 divider was:

``` text
9 + 7/27
```

Before this fix, `7/27` was evaluated as integer division and therefore
became zero. The returned sample rate was consequently:

``` text
RX888 Si5351 output divider:
samprate = vco / (1*(9 + 7/27)) = 66,666,666.666668 Hz
```

instead of the requested 64.8 MHz.

This resulted in incorrect filter geometry and repeated errors such as:

``` text
Block time 20.000 ms, block samples L=1,333,333,
overlap 5 (20.0%) M-1=333,333 samples,
forward FFT size N=1,666,666 real

Invalid filter output length 240 (fft size 299)
for input N=1666666, L=1333333
```

After the fix:

``` text
RX888 Si5351 output divider:
samprate = vco / (1*(9 + 7/27)) = 64,800,000.000001 Hz

Block time 20.000 ms, block samples L=1,296,000,
overlap 5 (20.0%) M-1=324,000 samples,
forward FFT size N=1,620,000 real
```

The filter errors disappear and the frontend operates at the expected
sample rate.

This was also verified operationally: receiver frequency calibration was
restored and HFDL decoding resumed normally.

## Regression

This regression was introduced in commit `0c24103c`
(`incomplete si5351 rational calculations`).

Before that commit, `rx888_set_samprate()` returned the exact rational
result:

``` c
return (double)best.fout_num / best.fout_den;
```

The commit replaced that with:

``` c
double const fout = vco / (best.R * (best.D + best.E/best.F));
```

Because `best.E` and `best.F` are integer types, `best.E / best.F`
performs integer division and truncates the fractional component before
the surrounding floating-point calculation.

For example, with a divider of `9 + 7/27`, the expression is evaluated
as `9 + 0`, causing the function to report approximately 66.666666 MHz
instead of 64.8 MHz.