### PR TITLE
filter: account for every skipped block, and let the caller keep RTP honest

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -659,6 +659,7 @@ int execute_filter_output(struct filter_out * const slave,int const shift){
   assert(slave->out_type == SPECTRUM || malloc_usable_size(slave->fdomain) >= slave->bins * sizeof(*slave->fdomain));
   // Wait for new block of output data
   pthread_mutex_lock(&master->filter_mutex);
+  unsigned const jobnum_at_entry = slave->next_jobnum; // to account for EVERY block we skip below
   int blocks_behind = (int)(master->completed_jobs[slave->next_jobnum % ND] - slave->next_jobnum);
   if(blocks_behind >= ND){
     // We've fallen too far behind. skip ahead to the oldest block still available
@@ -667,7 +668,6 @@ int execute_filter_output(struct filter_out * const slave,int const shift){
       if((int)(master->completed_jobs[i] - nextblock) < 0) // modular comparison
 	nextblock = master->completed_jobs[i];
     }
-    slave->block_drops += nextblock - slave->next_jobnum;
     slave->next_jobnum = nextblock;
   }
   while((int)(slave->next_jobnum - master->completed_jobs[slave->next_jobnum % ND]) > 0)
@@ -677,6 +677,15 @@ int execute_filter_output(struct filter_out * const slave,int const shift){
   // in case we just waited so long that the buffer wrapped, resynch
   slave->sample_index = master->samples_by_job[slave->next_jobnum % ND];
   slave->next_jobnum = master->completed_jobs[slave->next_jobnum % ND] + 1;
+  /* Account for every block skipped in this call, from BOTH paths: the
+     explicit "fallen too far behind" branch above AND the resynch on the
+     line above, which silently jumps ahead whenever the master refilled
+     our slot while we waited.  Normal progress is exactly one block, so
+     anything beyond that is discarded input the caller never sees.  The
+     caller must advance its output timestamp by this much or its RTP
+     timeline silently re-dates every sample that follows. */
+  slave->blocks_skipped = (slave->next_jobnum - jobnum_at_entry) - 1;
+  slave->block_drops += slave->blocks_skipped;
   pthread_mutex_unlock(&master->filter_mutex);
   assert(m_fdomain != NULL); // Should always be master frequency data
   // In spectrum mode we'll read directly from the input queue. Don't forget the 3dB scale when the input is real

--- a/src/filter.h
+++ b/src/filter.h
@@ -87,6 +87,7 @@ struct filter_out {
   fftwf_plan rev_plan;               // IFFT (frequency -> time)
   unsigned next_jobnum;
   unsigned block_drops;          // Lost frequency domain blocks, e.g., from late scheduling of slave thread
+  unsigned blocks_skipped;       // Blocks discarded by the LAST execute_filter_output() call, for output timestamp compensation
   int rcnt;                 // Samples read from output buffer
   uint64_t sample_index;     // input sample index at start of buffer
   bool beam;                 // Use complex weights alpha and beta

--- a/src/radio.c
+++ b/src/radio.c
@@ -1430,6 +1430,21 @@ int downconvert(chan_t *chan){
 
     execute_filter_output(&chan->filter.out,shift); // block until new data frame
 
+    /* If the filter discarded input blocks because this thread missed its
+       deadline, that time really elapsed -- it just produced no samples.
+       RTP timestamps count frames EMITTED, so unless we advance the output
+       timestamp by the discarded duration the stream stays numerically
+       contiguous while silently re-dating every following sample, and the
+       published (GPS_TIME, RTP_TIMESNAP) pair drifts by the lost time.
+       send_output() with a NULL buffer is the existing "keep timestamps and
+       mute state moving" path (see the squelch-closed case in linear.c); it
+       also sets chan->output.silent so the next packet carries the RTP
+       marker bit flagging the discontinuity to receivers. */
+    if(chan->filter.out.blocks_skipped > 0 && chan->filter.out.olen > 0){
+      send_output(chan, NULL, chan->filter.out.blocks_skipped * chan->filter.out.olen, true);
+      chan->filter.out.blocks_skipped = 0;
+    }
+
     if(chan->filter.out.output.c == NULL){
       chan->filter.bin_shift = shift; // Needed by spectrum.c in wideband mode
       chan->baseband = NULL;


### PR DESCRIPTION
`execute_filter_output()` advances `slave->next_jobnum` in two places, but only one of them counts.

The explicit "fallen too far behind" branch increments `block_drops`. The resynch immediately after the `cond_wait`

```c
slave->next_jobnum = master->completed_jobs[slave->next_jobnum % ND] + 1;
```

leaps the job number by however far the master moved while we waited, and increments nothing. On a loaded receiver that second path carries most of the loss — measured **84.5%** of it on one run here (28.963 s of 34.283 s), so `FILTER_DROPS` reported about 15% of what was actually discarded.

### Why it matters beyond the counter

The discarded blocks are real elapsed time that produced no samples. Because `audio.c` advances `chan->output.rtp.timestamp` by frames *emitted* rather than time *elapsed*, that time never reaches the RTP timeline. The stream stays numerically contiguous — **no sequence gap, no timestamp jump, no marker bit** — while every sample after the hole is silently re-dated, and the published `(GPS_TIME, RTP_TIMESNAP)` pair drifts by the lost duration.

A client that re-reads the status anchor continuously never notices. One that anchors once and projects arithmetically inherits the drift with no way to detect it. We chase ns-level HF timing against WWV/WWVH, so this cost us a great deal of confusion before we found it.

### Measurements

300 s capture at 129.6 MS/s, real RX888, deliberately driven over capacity. 297,690 packets captured off the wire:

| | stock | with this change |
|---|---|---|
| RTP sequence gaps | 0 | 0 |
| RTP timestamp anomalies | 0 | 1621 |
| RTP marker bits set | 0 | 1622 |
| wall-clock elapsed | 299.871 s | 299.548 s |
| RTP time advanced | 104.840 s | 299.560 s |
| **RTP fell behind by** | **195.031 s (65.04%)** | **−0.012 s (0.00%)** |
| `FILTER_DROPS` | 23.34 s | 192.14 s |

The patched build reports 192.14 s of dropped audio out of 299.5 s — essentially the 195 s the stock build lost silently at the same load. Same physical loss, one silently absorbed into the timestamps, the other counted and marker-flagged.

An eight-point load ramp shows the onset: at the first load where loss appears, `FILTER_DROPS` reports **zero** while 122 ms of timeline is gone. By the next step it admits 0.98 s of 14.43 s — 6.8%.

Reproduced hardware-free with the `sig_gen` front end (150 static channels, one CPU) if you want to see it without a receiver attached; happy to share that config.

### The change

Compute the skip from the total advance so both paths are covered, and expose it as `blocks_skipped` so `downconvert()` can advance the output timestamp by the discarded duration. That reuses the existing "keep timestamps and mute state moving" path — `send_output(chan, NULL, n, true)` — which already handles the Opus 48 kHz scaling and sets `chan->output.silent`, so the next packet carries the marker bit flagging the discontinuity.

Loss still happens under overload. It is now reported, correctly timed, and visible to clients instead of quietly re-dating the stream.

CPU is unchanged between builds at every load point tested — the accounting costs nothing.

Based on `e84506fb`. Happy to adjust the approach if you'd prefer the compensation elsewhere.