### PR TITLE
Serialize FFTW plan destruction for thread safety

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -160,6 +160,19 @@ fftwf_plan plan_c2r(int N, float complex *in, float *out){
   }
   return plan;
 }
+// FFTW only guarantees thread-safe execution of existing plans. Plan creation
+// and destruction must be serialized by the application. Use the same mutex for
+// both sides of the plan lifecycle so one demod cannot destroy FFTW planner state
+// while another demod is creating or destroying a plan.
+void destroy_plan(fftwf_plan *plan){
+  if(plan == NULL || *plan == NULL)
+    return;
+  pthread_mutex_lock(&FFTW_planning_mutex);
+  fftwf_destroy_plan(*plan);
+  pthread_mutex_unlock(&FFTW_planning_mutex);
+  *plan = NULL;
+}
+
 // Create fast convolution filters
 // The filters are now in two parts, filter_in (the master) and filter_out (the slave)
 // Filter_in holds the original time-domain input and its frequency domain version
@@ -310,10 +323,7 @@ int create_filter_output(struct filter_out *slave,struct filter_in * master,int 
     FREE(slave->response);
     pthread_mutex_unlock(&slave->response_mutex);
     FREE(slave->fdomain);
-    if(slave->rev_plan){
-      fftwf_destroy_plan(slave->rev_plan);
-      slave->rev_plan = NULL;
-    }
+    destroy_plan(&slave->rev_plan);
     FREE(slave->output_buffer.c);
     FREE(slave->output_buffer.r);
     slave->output.r = NULL;
@@ -910,9 +920,7 @@ int delete_filter_input(struct filter_in * master){
   ASSERT_UNLOCKED(&master->filter_mutex);
   pthread_mutex_destroy(&master->filter_mutex);
   pthread_cond_destroy(&master->filter_cond);
-  if(master->fwd_plan != NULL)
-    fftwf_destroy_plan(master->fwd_plan);
-  master->fwd_plan = NULL;
+  destroy_plan(&master->fwd_plan);
   mirror_free(&master->input_buffer,master->input_buffer_size); // Don't use free() !
   for(int i=0; i < ND; i++)
     FREE(master->fdomain[i]);
@@ -924,9 +932,7 @@ int delete_filter_output(struct filter_out *slave){
     return -1;
   ASSERT_UNLOCKED(&slave->response_mutex);
   pthread_mutex_destroy(&slave->response_mutex);
-  if(slave->rev_plan != NULL)
-    fftwf_destroy_plan(slave->rev_plan);
-  slave->rev_plan = NULL;
+  destroy_plan(&slave->rev_plan);
   // Only one will be non-null but it doesn't hurt to free both
   FREE(slave->output_buffer.c);
   FREE(slave->output_buffer.r);
@@ -1008,8 +1014,7 @@ int set_filter(struct filter_out * const slave,double low,double high,double con
     response[i] *= gain; // Normalize for the window gain
   assert(((uintptr_t)response & 63u) == 0);
   fftwf_execute(fwd_filter_plan);
-  fftwf_destroy_plan(fwd_filter_plan);
-  fwd_filter_plan = NULL;
+  destroy_plan(&fwd_filter_plan);
 #if FILTER_DEBUG
   {
     for(int i=0; i < N; i++)

--- a/src/filter.h
+++ b/src/filter.h
@@ -110,6 +110,7 @@ long lcm(long a,long b);
 fftwf_plan plan_complex(int N, float complex *in, float complex *out, int direction);
 fftwf_plan plan_r2c(int N, float *in, float complex *out);
 fftwf_plan plan_c2r(int N, float complex *in, float *out);
+void destroy_plan(fftwf_plan *plan);
 bool goodchoice(long);
 int ceil_pow2(uint32_t x);
 int set_filter_weights(struct filter_out *out,double complex i_weight, double complex q_weight);

--- a/src/spectrum.c
+++ b/src/spectrum.c
@@ -197,9 +197,7 @@ int demod_spectrum(void *arg){
   chan->spectrum.fft_n = 0;
   delete_filter_output(&chan->filter.out);
   chan->baseband = NULL;
-  if(chan->spectrum.plan)
-    fftwf_destroy_plan(chan->spectrum.plan);
-  chan->spectrum.plan = NULL;
+  destroy_plan(&chan->spectrum.plan);
   FREE(chan->spectrum.window);
   FREE(chan->spectrum.bin_data);
   FREE(chan->spectrum.ring);
@@ -682,8 +680,7 @@ static void setup_real_fft(chan_t *chan){
   assert(chan != NULL);
   if(chan->spectrum.fft_n < 1)
     return; // Can't do it yet
-  if(chan->spectrum.plan != NULL)
-    fftwf_destroy_plan(chan->spectrum.plan);
+  destroy_plan(&chan->spectrum.plan);
   float *in = fftwf_alloc_real(chan->spectrum.fft_n);
   assert(in != NULL);
   float complex *out = fftwf_alloc_complex(chan->spectrum.fft_n/2+1); // N/2 + 1 output points for real->complex
@@ -698,8 +695,7 @@ static void setup_complex_fft(chan_t *chan){
   assert(chan != NULL);
   if(chan->spectrum.fft_n < 1)
     return; // Can't do anything yet
-  if(chan->spectrum.plan != NULL)
-    fftwf_destroy_plan(chan->spectrum.plan);
+  destroy_plan(&chan->spectrum.plan);
   float complex *in = fftwf_alloc_complex(chan->spectrum.fft_n);
   assert(in != NULL);
   float complex *out = fftwf_alloc_complex(chan->spectrum.fft_n);


### PR DESCRIPTION
## Summary

Serialize FFTW plan destruction so concurrent demodulator teardown cannot
call FFTW plan-destruction routines at the same time.

## Background

While exercising multiple simultaneous receivers, I observed `radiod`
occasionally crash/core-dump during receiver teardown/reconfiguration,
particularly when multiple demodulators were being torn down concurrently.

Investigation highlighted a potential concurrency issue around FFTW plan
destruction.

FFTW documents its planner-related operations as not thread-safe by default.
Plan destruction is part of that interface, so concurrent calls to
`fftwf_destroy_plan()` should be serialized.

I cannot conclusively attribute every observed `radiod` crash to this race,
but the existing teardown path permits concurrent FFTW plan destruction and
therefore appears to violate FFTW's threading requirements.

FFT execution itself remains thread-safe and is not serialized by this change.

## Change

Add a mutex around FFTW plan destruction.

The lock is limited to destruction of FFTW plans; normal FFT execution and
signal-processing paths are unaffected.

## Scope

- No receiver configuration changes.
- No DSP algorithm changes.
- No serialization of FFT execution.
- Only FFTW plan destruction is serialized.

## Validation

Tested with multiple simultaneous KA9Q receivers, including concurrent receiver
creation and teardown.

Since deploying the serialization change in the production receiver environment,
I have not observed any further unexpected `radiod` crashes/core dumps.

Normal receiver operation and decoding have remained unchanged during testing.