### PR TITLE
Initialize linear RTP timestamp before first status response

### DIFF
--- a/src/linear.c
+++ b/src/linear.c
@@ -58,8 +58,15 @@ int demod_linear(void *arg){
   pthread_mutex_unlock(&chan->status.lock);
   realtime(chan->prio);
   do {
-    response(chan,response_needed);
-    response_needed = false;
+    // The initial status response must not advertise an RTP_TIMESNAP before
+    // the RTP timestamp has been tied to the frontend block/job timeline.
+    // pcmrecord uses GPS_TIME + RTP_TIMESNAP to timestamp new recordings; an
+    // early response with the zero-initialized RTP timestamp can therefore
+    // produce a bogus filename time when the first RTP packet arrives.
+    if(first_run || frontend->L == 0){
+      response(chan,response_needed);
+      response_needed = false;
+    }
     pthread_mutex_lock(&chan->status.lock);
     // Look on the command queue and grab just one atomically
     for(int i=0;i < CQLEN; i++){
@@ -92,6 +99,11 @@ int demod_linear(void *arg){
       if(Verbose > 0)
 	fprintf(stderr,"%s starting at FFT jobum %u, preset RTP TS to %u\n",chan->name,first_block,chan->output.rtp.timestamp);
       first_run = true;
+
+      // Now that RTP_TIMESNAP is valid, send the initial response that was
+      // deliberately deferred at the top of the loop.
+      response(chan,response_needed);
+      response_needed = false;
     }
 
     // First pass over sample block.


### PR DESCRIPTION
### Summary

Initialize the linear receiver RTP timestamp before sending the first status response.

A newly created linear channel could send its initial status response before `chan->output.rtp.timestamp` had been initialized from the current demodulator job position.

This meant the first status packet could advertise an uninitialized/stale `RTP_TIMESNAP`, while the first RTP data packet already used the newly initialized timestamp.

Consumers such as `pcmrecord` use the status clock/RTP snapshot pair to map RTP timestamps to wall-clock time. If `pcmrecord` received the premature status response, it could calculate an incorrect recording start time.

### Observed failure

This was reproducible when creating several dynamic receivers simultaneously.

For example, a recording started at approximately:

`2026-08-16 07:35:22 AEST`

but one `pcmrecord` filename was timestamped approximately:

`2026-08-15T23:50:34.5Z`

which is roughly 2h15m into the future.

The error closely matched:

`initial RTP timestamp / 12000 Hz`

i.e. approximately the current `radiod` uptime, consistent with `pcmrecord` combining a stale/zero initial `RTP_TIMESNAP` with the first initialized RTP timestamp.

### Change

Defer the initial status response until after the first successful downconversion has initialized the RTP timestamp.

The pending response is then sent immediately, preserving normal status behaviour while ensuring the first advertised RTP clock snapshot is valid.

### Validation

Tested with three simultaneously created 12 kHz USB receivers and separate `pcmrecord` instances.

Before the change, different receivers would intermittently receive incorrect filename timestamps around two hours into the future.

After the change, a test started at:

`2026-08-16 08:16:41 AEST`

produced:

- `9998400k2026-08-15T22:16:41.8Z.wav`
- `9998401k2026-08-15T22:16:41.8Z.wav`
- `9998402k2026-08-15T22:16:41.9Z.wav`

All three timestamps matched the actual recording start time within a fraction of a second.