### PR TITLE
Pass --no-fail to avahi-publish-address, matching avahi-publish-service

### DIFF
--- a/src/avahi.c
+++ b/src/avahi.c
@@ -83,7 +83,7 @@ int avahi_start(char const *service_name,char const *service_type,int const serv
 	fprintf(stderr,"%s %s %s %s\n",
 		"avahi-publish-address", "avahi-publish-address",dns_name,ip_address_string);
 #endif
-	execlp("avahi-publish-address", "avahi-publish-address",dns_name,ip_address_string, NULL);
+	execlp("avahi-publish-address", "avahi-publish-address","--no-fail",dns_name,ip_address_string, NULL);
 	perror("exec avahi publish address");
 	return -1;
       }


### PR DESCRIPTION
## Problem

`avahi.c` spawns two kinds of avahi helper children per stream. The `avahi-publish-service` children get `--no-fail`; the `avahi-publish-address` children on the line 24 lines below do not.

Without `--no-fail`, an avahi client exits as soon as its connection to avahi-daemon is disturbed — a network interface flap (address withdrawn/re-added) or an avahi-daemon restart. When that happens to the address publishers:

- the `<stream>.local` → multicast-IP **address records vanish**, so any client started afterwards cannot resolve any radiod stream name (`avahi-resolve-host-name` times out),
- already-running clients keep receiving (they joined the groups by IP long ago), and **service browsing still works** (those publishers survive thanks to `--no-fail`) — which makes the failure look like anything but mDNS,
- the dead children remain as `<defunct>` zombies since radiod never reaps them.

## Observed in production

At KFS (station KFS-NW, Ryzen/RX888, radiod started by the udev autostart): an interface flap coincided with radiod startup, killing all `avahi-publish-address` children at birth. `pcmrecord`/`wd-record` clients started later hung unresolvable while established ones kept decoding — WSPR silently off the air for half an hour while FT8/FT4/HFDL kept running. The `avahi-publish-service` siblings survived both that flap and a deliberate `systemctl restart avahi-daemon` test; the address publishers died both times. Restarting radiod (respawning the publishers) restored everything.

## Fix

One word: give the address publishers the same `--no-fail` the service publishers already have, so they wait out daemon/interface disturbances and re-register instead of dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)