### PR TITLE
Don't strlcpy dest_string onto itself in loadpreset()

### DIFF
--- a/src/modes.c
+++ b/src/modes.c
@@ -491,7 +491,11 @@ int loadpreset(chan_t *chan,dictionary const *table,char const *sname){
   }
   {
     char const *data = config_getstring(table,sname,"data",chan->output.dest_string);
-    strlcpy(chan->output.dest_string,data,sizeof chan->output.dest_string);
+    // config_getstring() hands back the default when the key is absent, i.e. this very
+    // buffer. strlcpy() is undefined on overlapping objects; macOS's fortified version
+    // traps on it, killing radiod before the first channel starts.
+    if(data != chan->output.dest_string)
+      strlcpy(chan->output.dest_string,data,sizeof chan->output.dest_string);
   }
   if(!chan->use_dns || resolve_mcast(chan->output.dest_string, &chan->output.dest_socket,DEFAULT_RTP_PORT,NULL,0,2) != 0){
     // Not using DNS, or DNS resolution failed: create a IPv4 multicast address from a hash of the name


### PR DESCRIPTION
Fixes #250.

`config_getstring()` returns the default pointer verbatim when the key is absent, so a section with no `data` entry makes `data == chan->output.dest_string` and the `strlcpy()` copies the buffer onto itself.

`strlcpy()` is undefined on overlapping objects. glibc tolerates it, so this is invisible on Linux, but macOS's fortified `strlcpy` traps on the overlap and `radiod` dies with `SIGTRAP` before starting its first channel — which in practice is any config with a channel section that doesn't set `data`.

The fix just skips the copy when source and destination are the same buffer. No behaviour change on Linux; the self-copy was already a no-op there.

Verified: with this applied, `radiod` starts on macOS 26.5.2 / arm64 with a `sig_gen` config, joins its multicast groups, demodulates, and answers `metadump` and `tune` normally. Builds clean with no new warnings.

Alternative, if you'd prefer: fix it at the `config_getstring()` call site by passing `NULL` as the default and only copying on a non-NULL return, or guard inside `config_getstring()` itself. The "pass a struct field as its own default" pattern could bite again elsewhere. Happy to redo it whichever way you like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqMVq98iEneqzJxwr4ij42
