### PR TITLE
make install: load firmware into an RX888 that was already plugged in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,15 @@ install:
 	for d in $(SUBDIRS); do \
 		$(MAKE) -C $$d install DESTDIR=$(DESTDIR) || exit $$?; \
 	done
+	# An RX888 that was already plugged in enumerated as the bare FX3 bootloader (04b4:00f3) before
+	# 70-rx888-boot.rules existed, so udev never saw an "add" event for it and rx888_boot.service
+	# was never started: radiod loops on "rx888_usb_init() failed" until the radio is power-cycled.
+	# Now that the loader, its service, the rules and /etc/radio/rx888_bootfile.conf are all in
+	# place, replay the "add" event for any such device so it gets its firmware without a replug.
+	@if [ -z "$(DESTDIR)" ] && command -v udevadm >/dev/null; then \
+		udevadm trigger --action=add --subsystem-match=usb \
+			--attr-match=idVendor=04b4 --attr-match=idProduct=00f3 || true; \
+	fi
 
 uninstall:
 	for d in $(SUBDIRS); do $(MAKE) -C $$d uninstall; done


### PR DESCRIPTION
Since firmware loading moved out of radiod, an RX888 gets its firmware only when udev sees an "add" event for the bare FX3 bootloader (04b4:00f3) and starts rx888_boot.service.  On a fresh machine the radio enumerated at boot, long before 'make install' created 70-rx888-boot.rules, so no "add" event is ever seen: the radio stays in bootloader mode until it is replugged or power-cycled, and radiod restarts every 5 seconds with "rx888_usb_init() failed".  A plain 'udevadm trigger' does not help, as it synthesizes "change" events and the rule matches "add" only.

At the end of the top-level install, replay the "add" event for any such device.  This has to run after the subdirectory loop rather than from rules/Makefile because rx888_boot.service reads FIRMWARE from /etc/radio/rx888_bootfile.conf, which config/ installs after rules/.  It is skipped when DESTDIR is set or udevadm is absent, matches only unprogrammed RX888s, and never fails the install.

Seen on a greenfield Debian 13 install at N8UR with 2026.08.20.