### PR TITLE
ka9q-cleanups: don't delete the ft4/ft8/wspr spool directories themselves

### DIFF
--- a/aux/ka9q-cleanups
+++ b/aux/ka9q-cleanups
@@ -1,2 +1,2 @@
 # delete any stale audio files for ft8, ft4 and wspr decoders
-10 * * * * radio   cd /var/lib/ka9q-radio; /usr/bin/find ft4 ft8 wspr -mmin +60 -delete > /dev/null 2>&1
+10 * * * * radio   cd /var/lib/ka9q-radio; /usr/bin/find ft4 ft8 wspr -mindepth 1 -mmin +60 -delete > /dev/null 2>&1


### PR DESCRIPTION
Without `-mindepth 1`, `find ft4 ft8 wspr -mmin +60 -delete` applies `-delete` to the starting points too. If a spool directory has been empty for more than 60 minutes its own mtime is stale, so find removes the directory.

That happens whenever the front end stops delivering samples for an hour. Seen on an RX888 host after radiod logged "No rx888 data ... quitting" but stayed alive: pcmrecord wrote nothing, the 10-past-the-hour cron run deleted `/var/lib/ka9q-radio/ft4` and `ft8`, and from then on the `ft[48]-record` and `ft[48]-decode` services logged

```
Can't open directory /var/lib/ka9q-radio/ft8: No such file or directory
```

every few seconds until something restarted them, about 19,000 journal lines over 22 hours on that host. `StateDirectory=` only recreates the directory on a service start, and `decode_ft8` never exits on this error, so the damage persists until a restart.

`-mindepth 1` limits `-delete` to the files (and lock files) under the spool directories, which is what the job is for.

Verified on the affected host with a throwaway tree: the current command removes an empty spool dir that has been idle 2 hours; with `-mindepth 1` all three dirs survive and only the stale file is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
