### PR TITLE
rtlsdr: return the input frequency from true_freq() when out of PLL range

### DIFF
--- a/src/rtlsdr.c
+++ b/src/rtlsdr.c
@@ -463,7 +463,7 @@ static double true_freq(uint64_t freq_hz){
       break;
   }
   if(div_num > MAX_DIV)
-    return 0; // Frequency out of range
+    return freq_hz; // Not modeled by this PLL (direct sampling, V4 upconverter, etc); pass through uncorrected
 
   // PLL programming bits: Nint in upper 16 bits, Nfract in lower 16 bits
   // Freq steps are pll_ref / 2^(16 + div_num) Hz


### PR DESCRIPTION
true_freq() models the R820T's fractional-N PLL and only produces a result when a divider brings the frequency into the VCO's range; below ~27.656MHz no divider fits. It previously returned 0 in that case, which set_correct_freq() fed straight into frontend->frequency, zeroing any tuning path that doesn't go through the PLL — direct sampling, and RTL-SDR V4's built-in upconverter, which tunes via the normal path and never sets direct_sampling.

Return freq_hz unchanged instead of 0 when no divider is found. The fix is now self-contained in true_freq(); set_correct_freq() needs no special-casing of its return value.