### PR TITLE
add rtp=no to let a channel skip RTP framing for direct unicast to plain UDP tools

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -76,7 +76,10 @@ int send_output(chan_t * restrict const chan, float const * restrict buffer, int
     chan->output.silent = false;
 
     uint8_t packet[PKTSIZE];
-    uint8_t * const dp = (uint8_t *)hton_rtp(packet,&rtp); // First byte after RTP header to be written
+    // rtp=no: send the bare payload with no RTP header at all (unicast point-to-point only --
+    // see loadpreset() in modes.c). RTP sequence/timestamp bookkeeping below still runs
+    // unchanged so status/metadata reporting is unaffected.
+    uint8_t * const dp = chan->output.no_rtp ? packet : (uint8_t *)hton_rtp(packet,&rtp);
     int chunk = frames;
     float const *buf = buffer;
 

--- a/src/modes.c
+++ b/src/modes.c
@@ -162,6 +162,7 @@ char const *Channel_keys[] = {
   "raster8",
   "raster9",
   "recovery-rate",
+  "rtp",
   "samprate",
   "shift",
   "snr-squelch",
@@ -470,6 +471,10 @@ int loadpreset(chan_t *chan,dictionary const *table,char const *sname){
     if(data != NULL)
       strlcpy(chan->output.dest_string,data,sizeof chan->output.dest_string);
   }
+  // rtp=no strips the RTP header from the wire; rtp state (ssrc/seq/timestamp) still
+  // updates normally below for status reporting. Inverted-sense self-referential default
+  // (same idiom as use_dns above) so an absent key leaves the current value unchanged.
+  chan->output.no_rtp = !config_getboolean(table,sname,"rtp",!chan->output.no_rtp);
   if(!chan->use_dns || resolve_mcast(chan->output.dest_string, &chan->output.dest_socket,DEFAULT_RTP_PORT,NULL,0,2) != 0){
     // Not using DNS, or DNS resolution failed: create a IPv4 multicast address from a hash of the name
     struct sockaddr_in *sin = (struct sockaddr_in *)&chan->output.dest_socket;
@@ -477,6 +482,21 @@ int loadpreset(chan_t *chan,dictionary const *table,char const *sname){
     sin->sin_family = AF_INET;
     sin->sin_addr.s_addr = htonl(addr);
     sin->sin_port = htons(DEFAULT_RTP_PORT);
+  }
+  if(chan->output.no_rtp){
+    // rtp=no drops the RTP header entirely, so SSRC can no longer distinguish channels
+    // sharing a destination. Only safe with a true unicast, one-channel-per-destination
+    // target (dns=yes, data=host:port). Warn rather than block, in case someone really
+    // does want a single-channel multicast group this way.
+    struct sockaddr const *sa = (struct sockaddr *)&chan->output.dest_socket;
+    bool is_mcast = false;
+    if(sa->sa_family == AF_INET)
+      is_mcast = (ntohl(((struct sockaddr_in const *)sa)->sin_addr.s_addr) >> 28) == 0xe;
+    else if(sa->sa_family == AF_INET6)
+      is_mcast = ((struct sockaddr_in6 const *)sa)->sin6_addr.s6_addr[0] == 0xff;
+    if(is_mcast)
+      fprintf(stderr,"%s: warning: rtp=no with multicast destination %s -- streams sharing that group will be unrecoverable without RTP/SSRC framing\n",
+	      chan->name,chan->output.dest_string);
   }
   // --> Should ensure the channel data stream is distinct from the radiod status port !!
   // Status sent to same data stream group, different port

--- a/src/radio.h
+++ b/src/radio.h
@@ -266,6 +266,7 @@ struct channel {
     double deemph_state_right;
     uint64_t samples;
     bool pacing;           // Pace output packets
+    bool no_rtp;           // Set by rtp=no: skip RTP header on the wire (unicast point-to-point only)
     enum encoding encoding;
     float *queue;          // delayed output data for aggregation when minpacket > 0
     int queue_length;      // Size of allocation, in floats


### PR DESCRIPTION
no framing also means no loss detection, which matters most on iq-preset channels (demod=linear, stereo=yes) since a dropped datagram can permanently swap i/q with nothing left to track the pair boundary. fine for casual audio, riskier for anything doing coherent processing downstream.

playback (match rate/channels/port to the channel's rtp=no config):

  `ffmpeg -f s16le -ar <rate> -ac <channels> -i udp://@:<port> -f alsa default`

or via socat, if you'd rather not depend on ffmpeg's own udp handling:

  `socat -u UDP-LISTEN:<port>,reuseaddr - | ffmpeg -f s16le -ar <rate> -ac <channels> -i - -f alsa default`